### PR TITLE
Make Keys, Values, and ItemsView subscriptable

### DIFF
--- a/pvl/_collections.py
+++ b/pvl/_collections.py
@@ -52,7 +52,7 @@ class ItemsView(MappingView):
             yield item
 
     def __getitem__(self, index):
-        return list(self._mapping)[index]
+        return self._mapping[index]
 
 
 class ValuesView(MappingView):

--- a/pvl/_collections.py
+++ b/pvl/_collections.py
@@ -34,6 +34,13 @@ class KeysView(MappingView):
         for key, _ in self._mapping:
             yield key
 
+    def __getitem__(self, index):
+        return self._mapping[index][0]
+
+    def __repr__(self):
+        keys = [key for key, _ in self._mapping]
+        return '%s(%r)' % (type(self).__name__, keys)
+
 
 class ItemsView(MappingView):
     def __contains__(self, item):
@@ -43,6 +50,9 @@ class ItemsView(MappingView):
     def __iter__(self):
         for item in self._mapping:
             yield item
+
+    def __getitem__(self, index):
+        return list(self._mapping)[index]
 
 
 class ValuesView(MappingView):
@@ -55,6 +65,13 @@ class ValuesView(MappingView):
     def __iter__(self):
         for _, value in self._mapping:
             yield value
+
+    def __getitem__(self, index):
+        return self._mapping[index][1]
+
+    def __repr__(self):
+        values = [value for _, value in self._mapping]
+        return '%s(%r)' % (type(self).__name__, values)
 
 
 class OrderedMultiDict(dict, MutableMapping):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -368,6 +368,39 @@ def test_py2_items():
     assert module.values() == [1, 2, 3]
 
 
+@pytest.mark.skipif(six.PY2, reason='requires python3')
+def test_py3_items():
+    module = pvl.PVLModule()
+
+    assert isinstance(module.items(), pvl._collections.ItemsView)
+    with pytest.raises(IndexError):
+        module.items()[0]
+
+    assert isinstance(module.keys(), pvl._collections.KeysView)
+    with pytest.raises(IndexError):
+        module.keys()[0]
+
+    assert isinstance(module.values(), pvl._collections.ValuesView)
+    with pytest.raises(IndexError):
+        module.values()[0]
+
+    module = pvl.PVLModule([
+        ('a', 1),
+        ('b', 2),
+        ('a', 3),
+    ])
+
+    assert isinstance(module.items(), pvl._collections.ItemsView)
+    assert module.items()[0] == ('a', 1)
+
+    assert isinstance(module.keys(), pvl._collections.KeysView)
+    assert module.keys()[0] == 'a'
+
+    assert isinstance(module.values(), pvl._collections.ValuesView)
+    assert module.values()[0] == 1
+
+
+
 if six.PY3:
     def iteritems(module):
         return module.items()


### PR DESCRIPTION
Fixes #24 

[KeysView](https://github.com/planetarypy/pvl/compare/master...pbvarga1:issue24?expand=1#diff-f7a99951f36ff3e9c644549213c6538eR29), [ValuesView](https://github.com/planetarypy/pvl/compare/master...pbvarga1:issue24?expand=1#diff-f7a99951f36ff3e9c644549213c6538eR45), and [ValuesView](https://github.com/planetarypy/pvl/compare/master...pbvarga1:issue24?expand=1#diff-f7a99951f36ff3e9c644549213c6538eR45) now have a ``__getitem__`` method so they can be subscriptable in a similar way that ``keys()``, ``values()``, and ``items()`` are subscriptable for normal dictionaries. I also adjusted their ``__repr__`` methods to show the correct information in tandem with their dictionary method counterpart. 

Example:

```python
In [1]: import pvl

In [2]: module = pvl.PVLModule([
   ...:         ('a', 1),
   ...:         ('b', 2),
   ...:         ('a', 3),
   ...:     ])

In [3]: module.items()[0]
Out[3]: ('a', 1)

In [4]: module = pvl.load('tests/data/pattern.cub')

In [5]: module.keys()
Out[5]: KeysView(['IsisCube', 'Label'])

In [6]: module.values()[1]
Out[6]: 
PVLObject([
  ('Bytes', 65536)
])
```