### PR TITLE
Fix Issue #23 - Add insert_before/after methods

### DIFF
--- a/pvl/_collections.py
+++ b/pvl/_collections.py
@@ -258,7 +258,7 @@ class OrderedMultiDict(dict, MutableMapping):
     def copy(self):
         return type(self)(self)
 
-    def _insert_wrapper(func):
+    def __insert_wrapper(func):
         """Make sure the arguments given to the insert methods are correct"""
         def check_func(self, key, new_item, instance=0):
             if key not in self.keys():
@@ -278,12 +278,11 @@ class OrderedMultiDict(dict, MutableMapping):
         else:
             occurrence = -1
             for index, k in enumerate(self.keys()):
-                if k == key and occurrence == instance:
-                    # Found the key and the correct occurence of the key
-                    break
-                elif k == key and occurrence != instance:
-                    # Found the key but not the right occurence of the key
+                if k == key:
                     occurrence += 1
+                    if occurrence == instance:
+                        # Found the key and the correct occurence of the key
+                        break
 
             if occurrence != instance:
                 # Gone through the entire list of keys and the instance number
@@ -302,13 +301,20 @@ class OrderedMultiDict(dict, MutableMapping):
         index = self._get_index_for_insert(key, instance)
         index = index + 1 if is_after else index
         self.__items = self.__items[:index] + new_item + self.__items[index:]
+        # Make sure indexing works with new items
+        for new_key, new_value in new_item:
+            if new_key in self:
+                value_list = [val for k, val in self.__items if k == new_key]
+                dict_setitem(self, new_key, value_list)
+            else:
+                dict_setitem(self, new_key, [new_value])
 
-    @_insert_wrapper
+    @__insert_wrapper
     def insert_after(self, key, new_item, instance=0):
         """Insert an item after a key"""
         self._insert_item(key, new_item, instance, True)
 
-    @_insert_wrapper
+    @__insert_wrapper
     def insert_before(self, key, new_item, instance=0):
         """Insert an item before a key"""
         self._insert_item(key, new_item, instance, False)

--- a/pvl/_collections.py
+++ b/pvl/_collections.py
@@ -58,6 +58,10 @@ class ItemsView(MappingView):
     def __getitem__(self, index):
         return self._mapping[index]
 
+    def index(self, item):
+        items = [i for i in self._mapping]
+        return items.index(item)
+
 
 class ValuesView(MappingView):
     def __contains__(self, value):
@@ -78,7 +82,7 @@ class ValuesView(MappingView):
         return '%s(%r)' % (type(self).__name__, values)
 
     def index(self, value):
-        values = [v for v, _ in self._mapping]
+        values = [val for _, val in self._mapping]
         return values.index(value)
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -358,14 +358,25 @@ def test_py2_items():
         ('a', 3),
     ])
 
-    assert isinstance(module.items(), list)
-    assert module.items() == [('a', 1), ('b', 2), ('a', 3)]
+    items = module.items()
+    assert isinstance(items, list)
+    assert items == [('a', 1), ('b', 2), ('a', 3)]
+    assert items.index(('a', 1)) == 0
+    assert items.index(('b', 2)) == 1
+    assert items.index(('a', 3)) == 2
 
-    assert isinstance(module.keys(), list)
-    assert module.keys() == ['a', 'b', 'a']
+    keys = module.keys()
+    assert isinstance(keys, list)
+    assert keys == ['a', 'b', 'a']
+    assert keys.index('a') == 0
+    assert keys.index('b') == 1
 
-    assert isinstance(module.values(), list)
-    assert module.values() == [1, 2, 3]
+    values = module.values()
+    assert isinstance(values, list)
+    assert values == [1, 2, 3]
+    assert values.index(1) == 0
+    assert values.index(2) == 1
+    assert values.index(3) == 2
 
 
 @pytest.mark.skipif(six.PY2, reason='requires python3')
@@ -391,19 +402,30 @@ def test_py3_items():
     ])
 
     assert isinstance(module.items(), pvl._collections.ItemsView)
-    assert module.items()[0] == ('a', 1)
-    assert module.items()[1] == ('b', 2)
-    assert module.items()[2] == ('a', 3)
+    items = module.items()
+    assert items[0] == ('a', 1)
+    assert items[1] == ('b', 2)
+    assert items[2] == ('a', 3)
+    assert items.index(('a', 1)) == 0
+    assert items.index(('b', 2)) == 1
+    assert items.index(('a', 3)) == 2
 
     assert isinstance(module.keys(), pvl._collections.KeysView)
-    assert module.keys()[0] == 'a'
-    assert module.keys()[1] == 'b'
-    assert module.keys()[2] == 'a'
+    keys = module.keys()
+    assert keys[0] == 'a'
+    assert keys[1] == 'b'
+    assert keys[2] == 'a'
+    assert keys.index('a') == 0
+    assert keys.index('b') == 1
 
     assert isinstance(module.values(), pvl._collections.ValuesView)
-    assert module.values()[0] == 1
-    assert module.values()[1] == 2
-    assert module.values()[2] == 3
+    values = module.values()
+    assert values[0] == 1
+    assert values[1] == 2
+    assert values[2] == 3
+    assert values.index(1) == 0
+    assert values.index(2) == 1
+    assert values.index(3) == 2
 
 
 if six.PY3:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -557,79 +557,111 @@ def test_conversion():
 
 
 @pytest.mark.parametrize(
-    'expected, key, instance', [
+    'expected_label, key, instance, expected_list, expected_value', [
         ([
-            ('new', 'item'),
+            ('a', 4),
             ('a', 1),
             ('b', 2),
             ('a', 3),
-        ], 'a', 0),
+            ('c', 5),
+        ], 'a', 0, [4, 1, 3], 4),
         ([
             ('a', 1),
-            ('new', 'item'),
+            ('a', 4),
             ('b', 2),
             ('a', 3),
-        ], 'b', 0),
+            ('c', 5),
+        ], 'b', 0, [1, 4, 3], 1),
         ([
             ('a', 1),
             ('b', 2),
-            ('new', 'item'),
+            ('a', 4),
             ('a', 3),
-        ], 'a', 1)
+            ('c', 5),
+        ], 'a', 1, [1, 4, 3], 1),
+        ([
+            ('a', 1),
+            ('b', 2),
+            ('a', 3),
+            ('a', 4),
+            ('c', 5),
+        ], 'c', 0, [1, 3, 4], 1)
     ])
-def test_insert_before(expected, key, instance):
+def test_insert_before(expected_label, key, instance, expected_list,
+                        expected_value):
     module1 = pvl.PVLModule([
         ('a', 1),
         ('b', 2),
         ('a', 3),
+        ('c', 5),
     ])
     module2 = module1.copy()
 
-    expected_module = pvl.PVLModule(expected)
+    expected_module = pvl.PVLModule(expected_label)
 
-    module1.insert_before(key, [('new', 'item')], instance)
+    module1.insert_before(key, [('a', 4)], instance)
     assert expected_module == module1
+    assert module1['a'] == expected_value
+    assert module1.getlist('a') == expected_list
 
-    module2.insert_before(key, pvl.PVLModule([('new', 'item')]), instance)
+    module2.insert_before(key, pvl.PVLModule([('a', 4)]), instance)
     assert module2 == expected_module
+    assert module1['a'] == expected_value
+    assert module1.getlist('a') == expected_list
 
 
 @pytest.mark.parametrize(
-    'expected, key, instance', [
+    'expected_label, key, instance, expected_list, expected_value', [
         ([
             ('a', 1),
-            ('new', 'item'),
+            ('a', 4),
             ('b', 2),
             ('a', 3),
-        ], 'a', 0),
-        ([
-            ('a', 1),
-            ('b', 2),
-            ('new', 'item'),
-            ('a', 3),
-        ], 'b', 0),
+            ('c', 5),
+        ], 'a', 0, [1, 4, 3], 1),
         ([
             ('a', 1),
             ('b', 2),
+            ('a', 4),
             ('a', 3),
-            ('new', 'item'),
-        ], 'a', 1)
+            ('c', 5),
+        ], 'b', 0, [1, 4, 3], 1),
+        ([
+            ('a', 1),
+            ('b', 2),
+            ('a', 3),
+            ('a', 4),
+            ('c', 5),
+        ], 'a', 1, [1, 3, 4], 1),
+        ([
+            ('a', 1),
+            ('b', 2),
+            ('a', 3),
+            ('c', 5),
+            ('a', 4),
+        ], 'c', 0, [1, 3, 4], 1)
     ])
-def test_insert_after(expected, key, instance):
+def test_insert_after(expected_label, key, instance, expected_list,
+                        expected_value):
     module1 = pvl.PVLModule([
         ('a', 1),
         ('b', 2),
         ('a', 3),
+        ('c', 5),
     ])
     module2 = module1.copy()
 
-    expected_module = pvl.PVLModule(expected)
+    expected_module = pvl.PVLModule(expected_label)
 
-    module1.insert_after(key, [('new', 'item')], instance)
+    module1.insert_after(key, [('a', 4)], instance)
     assert expected_module == module1
+    assert module1['a'] == expected_value
+    assert module1.getlist('a') == expected_list
 
-    module2.insert_after(key, pvl.PVLModule([('new', 'item')]), instance)
+    module2.insert_after(key, pvl.PVLModule([('a', 4)]), instance)
     assert module2 == expected_module
+    assert module1['a'] == expected_value
+    assert module1.getlist('a') == expected_list
 
 
 @pytest.mark.parametrize(

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -111,3 +111,33 @@ def test_quoated_strings():
 
     encoder = pvl.encoder.PDSLabelEncoder
     assert module == pvl.loads(pvl.dumps(module, cls=encoder))
+
+
+def test_dump_to_file_insert_before():
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        for filename in PDS_LABELS:
+            label = pvl.load(filename)
+            if os.path.basename(filename) != 'empty.lbl':
+                label.insert_before('PDS_VERSION_ID', [('new', 'item')])
+            tmpfile = os.path.join(tmpdir, os.path.basename(filename))
+            pvl.dump(label, tmpfile)
+            assert label == pvl.load(tmpfile)
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_dump_to_file_insert_after():
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        for filename in PDS_LABELS:
+            label = pvl.load(filename)
+            if os.path.basename(filename) != 'empty.lbl':
+                label.insert_after('PDS_VERSION_ID', [('new', 'item')])
+            tmpfile = os.path.join(tmpdir, os.path.basename(filename))
+            pvl.dump(label, tmpfile)
+            assert label == pvl.load(tmpfile)
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
Fixes #23 

Pull request gives ability to add entries to the label like so:

```python
>>> import pvl
>>> # Basic Example
>>> module = pvl.PVLModule([
        ('a', 1),
        ('b', 2),
        ('a', 3),
    ])
>>> # Insert simple list of key and value before the first 'a'
>>> module.insert_before(key='a', new_item=[('c', 4)])
>>> module
PVLModule([
  ('c', 4)
  ('a', 1)
  ('b', 2)
  ('a', 3)
])
>>> # Insert simple list after the second a
>>> module.insert_after('a', [('d', 5)], instance=1)
>>> module
PVLModule([
  ('c', 4)
  ('a', 1)
  ('b', 2)
  ('a', 3)
  ('d', 5)
])
>>> # Insert before the second a
>>> module.insert_before('a', [('e', 6)], 1)
>>> module
PVLModule([
  ('c', 4)
  ('a', 1)
  ('b', 2)
  ('e', 6)
  ('a', 3)
  ('d', 5)
])

>>> # More Inserting items into groups
>>> module = pvl.load('tests/data/pattern.cub')
>>> module['IsisCube']['Core']
PVLObject([
  ('StartByte', 65537)
  ('Format', 'Tile')
  ('TileSamples', 128)
  ('TileLines', 128)
  ('Dimensions', PVLGroup([
    ('Samples', 90)
    ('Lines', 90)
    ('Bands', 1)
  ]))
  ('Pixels',
   {'Base': 0.0,
    'ByteOrder': 'Lsb',
    'Multiplier': 1.0,
    'Type': 'Real'})
])
>>> # The value can be a PVLModule
>>> module['IsisCube']['Core'].insert_before(
        'Dimensions', [('foo', pvl.PVLModule([('monty', 'python')]))])
>>> module['IsisCube']['Core']
PVLObject([
  ('StartByte', 65537)
  ('Format', 'Tile')
  ('TileSamples', 128)
  ('TileLines', 128)
  ('foo', PVLModule([
    ('monty', 'python')
  ]))
  ('Dimensions', PVLGroup([
    ('Samples', 90)
    ('Lines', 90)
    ('Bands', 1)
  ]))
  ('Pixels',
   {'Base': 0.0,
    'ByteOrder': 'Lsb',
    'Multiplier': 1.0,
    'Type': 'Real'})
])
>>> # Insert a PVLModule
>>>  module['IsisCube']['Core'].insert_after(
        'Dimensions', pvl.PVLModule([('bar', pvl.PVLModule([('life', 42)]))]))
>>> module['IsisCube']['Core']
PVLObject([
  ('StartByte', 65537)
  ('Format', 'Tile')
  ('TileSamples', 128)
  ('TileLines', 128)
  ('foo', PVLModule([
    ('monty', 'python')
  ]))
  ('Dimensions', PVLGroup([
    ('Samples', 90)
    ('Lines', 90)
    ('Bands', 1)
  ]))
  ('bar', PVLModule([
    ('life', 42)
  ]))
  ('Pixels',
   {'Base': 0.0,
    'ByteOrder': 'Lsb',
    'Multiplier': 1.0,
    'Type': 'Real'})
])
>>> module
PVLModule([
  ('IsisCube',
   {'Core': {'Dimensions': {'Bands': 1,
                            'Lines': 90,
                            'Samples': 90},
             'Format': 'Tile',
             'Pixels': {'Base': 0.0,
                        'ByteOrder': 'Lsb',
                        'Multiplier': 1.0,
                        'Type': 'Real'},
             'StartByte': 65537,
             'TileLines': 128,
             'TileSamples': 128,
             'bar': PVLModule([
    ('life', 42)
  ]),
             'foo': PVLModule([
    ('monty', 'python')
  ])}})
  ('Label', PVLObject([
    ('Bytes', 65536)
  ]))
])

>>> # Example following that from issue 23
>>> label = pvl.loads("""
     PDS_VERSION_ID = a 
     DD_VERSION_ID = b
     LABEL_REVISION_NOTE = c
     ^IMAGE = d
 """)
>>> extra = [
      ('LABEL_REVISION_NOTE', 'more'),
      ('DATA_SET_ID', 'more'),
      ('PRODUCT_ID', 'more'),
      ('INSTRUMENT_HOST_NAME', 'more'),
]
>>> label['LABEL_REVISION_NOTE']
'c'
>>> label.insert_before('DD_VERSION_ID', extra)
>>> label
PVLModule([
  ('PDS_VERSION_ID', 'a')
  ('LABEL_REVISION_NOTE', 'more')
  ('DATA_SET_ID', 'more')
  ('PRODUCT_ID', 'more')
  ('INSTRUMENT_HOST_NAME', 'more')
  ('DD_VERSION_ID', 'b')
  ('LABEL_REVISION_NOTE', 'c')
  ('^IMAGE', 'd')
])
>>> # A key with multiple values returns the first and this is reflected in insertion
>>> label['LABEL_REVISION_NOTE']
'more'
>>> label.getlist('LABEL_REVISION_NOTE')
['more', 'c']
>>> label.insert_after('PRODUCT_ID', [('LABEL_REVISION_NOTE', 'even_more')])
>>> label['LABEL_REVISION_NOTE']
'more'
>>> label.getlist('LABEL_REVISION_NOTE')
['more', 'even_more', 'c']
```

CC: @andywinhold 