### PR TITLE
Bugfix parsing number from ISIS3 array

### DIFF
--- a/pvl/_numbers.py
+++ b/pvl/_numbers.py
@@ -34,8 +34,6 @@ def is_number(value):
 
 
 def parse_number(value):
-    if value.endswith(b'-'):
-        value = value[:-1]
     if is_integer(value):
         return int(value, 10)
 

--- a/pvl/_numbers.py
+++ b/pvl/_numbers.py
@@ -34,7 +34,7 @@ def is_number(value):
 
 
 def parse_number(value):
-    if value.endswith('-'):
+    if value.endswith(b'-'):
         value = value[:-1]
     if is_integer(value):
         return int(value, 10)

--- a/pvl/_numbers.py
+++ b/pvl/_numbers.py
@@ -34,6 +34,8 @@ def is_number(value):
 
 
 def parse_number(value):
+    if value.endswith('-'):
+        value = value[:-1]
     if is_integer(value):
         return int(value, 10)
 

--- a/pvl/decoder.py
+++ b/pvl/decoder.py
@@ -747,9 +747,6 @@ class PVLDecoder(object):
 
             self.skip_whitespace_or_comment(stream)
 
-            if not self.has_unquoated_string(stream):
-                break
-
             value = value[:-1]
 
         return self.cast_unquoated_string(value)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -39,7 +39,15 @@ def test_assignment():
 
     label = pvl.loads('foo=bar-\n')
     assert isinstance(label, Label)
-    assert label['foo'] == 'bar-'
+    assert label['foo'] == 'bar'
+
+    label = pvl.loads('foo=bro-\nken')
+    assert isinstance(label, Label)
+    assert label['foo'] == 'broken'
+
+    label = pvl.loads('foo=bro-\n ken')
+    assert isinstance(label, Label)
+    assert label['foo'] == 'broken'
 
 
 def test_spacing():

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -556,6 +556,8 @@ def test_sequence():
         multiline = (a,
                      b,
                      c)
+        linewrap = (1.234,1.2-
+                     34,1.234)
         End
     """)
 
@@ -591,6 +593,12 @@ def test_sequence():
     assert label['multiline'][0] == 'a'
     assert label['multiline'][1] == 'b'
     assert label['multiline'][2] == 'c'
+
+    assert isinstance(label['linewrap'], list)
+    assert len(label['linewrap']) == 3
+    assert label['linewrap'][0] == 1.234
+    assert label['linewrap'][1] == 1.234
+    assert label['linewrap'][2] == 1.234
 
 
 def test_units():

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -557,7 +557,8 @@ def test_sequence():
                      b,
                      c)
         linewrap = (1.234,1.2-
-                     34,1.234)
+                    34,1.234-
+                    ,1.234)
         End
     """)
 
@@ -595,10 +596,11 @@ def test_sequence():
     assert label['multiline'][2] == 'c'
 
     assert isinstance(label['linewrap'], list)
-    assert len(label['linewrap']) == 3
+    assert len(label['linewrap']) == 4
     assert label['linewrap'][0] == 1.234
     assert label['linewrap'][1] == 1.234
     assert label['linewrap'][2] == 1.234
+    assert label['linewrap'][3] == 1.234
 
 
 def test_units():


### PR DESCRIPTION
I notice a small bug during the parsing of numbers from ISIS3 array.

Here is a sample of a Casini/VIMS cube header produced by ISIS3:
```
Object = IsisCube
  Group = BandBin
    Center         = (0.89261,0.909067,0.925522,0.941972,0.95841,0.974852,0.9-
                      91281,1.00771,1.02413,1.04055,1.05696,1.07335,1.08976,1.-
                      10616,1.12257,1.13896,1.15535,1.17174,1.18813,1.20451,1.-
                      2209,1.23728,1.25367,1.27005,1.28642,1.3028,1.31919,1.33-
                      557,1.35196,1.36834,1.38472,1.4011,1.4175,1.43389,1.4502-
                      9,1.46669,1.48309,1.49949,1.51591,1.53233,1.54875,1.5651-
                      8,1.58161,1.59805,1.61452,1.63094,1.6474,1.66386,1.68033-
                      ,1.69679,1.71327,1.72974,1.74622,1.7627,1.77918,1.79566,-
                      1.81214,1.82862,1.8451,1.86158,1.87806,1.89453,1.91101,1-
                      .92748,1.94395,1.96041,1.97688,1.99334,2.00981,2.02628,2-
                      .04276,2.05924,2.07574,2.09223,2.10874,2.12527,2.1418,2.-
                      15835,2.17492,2.1915,2.20811,2.22472,2.24135,2.25798,2.2-
                      7462,2.29125,2.30789,2.32452,2.34114,2.35776,2.37437,2.3-
                      9096,2.40755,2.42414,2.44072,2.45729,2.47387,2.49044,2.5-
                      0701,2.52358,2.54015,2.55673,2.5733,2.58988,2.60647,2.62-
                      307,2.63966,2.65626,2.67287,2.6895,2.70612,2.72274,2.739-
                      4,2.75603,2.77267,2.78933,2.80599,2.82266,2.83932,2.8559-
                      9,2.87266,2.88934,2.90601,2.9227,2.93938,2.95606,2.97274-
                      ,2.98941,3.00617,3.02283,3.03952,3.05624,3.07293,3.08963-
                      ,3.10632,3.12301,3.13972,3.15642,3.17312,3.18981,3.20651-
                      ,3.2232,3.2399,3.25658,3.27327,3.28996,3.30664,3.32331,3-
                      .33999,3.35666,3.37332,3.38998,3.40665,3.42331,3.43997,3-
                      .45663,3.47329,3.48994,3.5066,3.52325,3.5399,3.55656,3.5-
                      7321,3.58986)
  End_Group
End_Object
End
```
Most of the array is parsed corrected but some values remain Unicode strings (with a `-` symbol at the end), e.g.:
```
...
u'1.68033-',
...
u'2.97274-',
...
u'3.08963-',
...
u'3.20651-',
...
```
It always happen when the next line starts with a `,`.

I guess there is a nicer way to solve that problem, but here is dirty patch to fix it quickly.