### PR TITLE
1.0.0-alpha.1: Quantity Objects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,8 @@ backwards-incompatible changes are being introduced to the codebase.
 * The library now properly parses quoted strings that include backslashes
   as detailed in #33.
 * Utility programs pvl_validate and pvl_translate were added.
+* The ability to deal with 3rd-party 'quantity' objects like astropy.units.Quantity
+  and pint.Quantity was added and documented, addresses #22.
 * Documentation was updated and expanded.
 
 0.3.0 (2017-06-28)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.0.0-alpha.2 (2020-04-18)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* The ability to deal with 3rd-party 'quantity' objects like astropy.units.Quantity
+  and pint.Quantity was added and documented, addresses #22.
+
 1.0.0-alpha.1 (2020-04-17)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This is a bugfix on 1.0.0-alpha to properly parse scientific notation
@@ -70,8 +75,6 @@ backwards-incompatible changes are being introduced to the codebase.
 * The library now properly parses quoted strings that include backslashes
   as detailed in #33.
 * Utility programs pvl_validate and pvl_translate were added.
-* The ability to deal with 3rd-party 'quantity' objects like astropy.units.Quantity
-  and pint.Quantity was added and documented, addresses #22.
 * Documentation was updated and expanded.
 
 0.3.0 (2017-06-28)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to pvl's documentation!
    readme
    parsing
    encoding
+   quantities
    utility
    standards
    modules

--- a/docs/quantities.rst
+++ b/docs/quantities.rst
@@ -1,0 +1,205 @@
+============================
+Quantities: Values and Units
+============================
+
+The PVL specifications supports the notion that PVL Value Expressions
+can contain an optional PVL Units Expression that follows the PVL Value.
+
+By default, the ``pvl`` library includes the :class:`pvl._collections.Units`
+class which is implemented as a :class:`collections.namedtuple` with
+a ``value`` and a ``unit`` parameter.  This kind of Python object, although
+not supported by the standard library, is sometimes also referred to as a
+'quantity' object in other 3rd party libraries.
+
+This means that when PVL text is parsed by :func:`pvl.load` or
+:func:`pvl.loads` when a PVL Value followed by a PVL Units Expression
+is encountered, the returned Python object will be a
+:class:`pvl._collections.Units` object.
+
+Likewise when :func:`pvl.dump` or :func:`pvl.dumps` encounters a
+:class:`pvl._collections.Units` its value and units will be serialized
+with the right PVL syntax.
+
+However, the ``pvl`` library also supports the use of other quantity objects.
+
+--------------------------------------------
+Getting other quantity objects from PVL text
+--------------------------------------------
+
+In order to get the parsing side of the ``pvl`` library to return a particular
+kind of quantity object when a PVL Value followed by a PVL Units Expression
+is found, can be achieved by passing the name of that quantity class to the
+decoder's ``quantity_cls`` argument.  This quantity class's constructor must
+take two arguments, where the first will receive the PVL Value (as whatever
+Python type ``pvl`` determines it to be) and the second will receive the 
+PVL Units Expression (as a ``str``).
+
+Examples of how to do this with :func:`pvl.load` or :func:`pvl.loads` are below
+for ``astropy`` and ``pint``.
+
+Depending on the PVL text that you are parsing, and the quantity class that you
+are using, you may get errors if the quantity class can't accept the PVL Units
+Expression, or if the *value* part of the quantity class can't handle all of the
+possible types of PVL Values (which can be Simple Values, Sets, or Sequences).
+
+
+----------------------------------------------
+Writing out other quantity objects to PVL text
+----------------------------------------------
+
+In order to get the encoding side of the ``pvl`` library to write out the
+correct kind of PVL text based on some quantity object is more difficult 
+due to the wide variety of ways that quantity objects are written in 3rd 
+party libaries.  At this time, the ``pvl`` library can properly encode
+:class:`pvl._collecitons.Units`, :class:`astropy.units.Quantity`, and
+:class:`pint.Quantity` objects (or objects that pass an ``isinstance()``
+test for those objects).  Any other kind of quantity object in the 
+data structure passed to :func:`pvl.dump` or :func:`pvl.dumps` will
+just be encoded as a string.
+
+Other types are possible, but require subclassing the encoder classes, or
+submitting a PR to the repo to add them.
+
+
+----------------------
+astropy.units.Quantity
+----------------------
+
+The Astropy Project has classes for handing `Units and Quantities
+<https://docs.astropy.org/en/stable/units/>`_.
+
+The :class:`astropy.units.Quantity` object can be returned in the data
+structure returned from :func:`pvl.load` or :func:`pvl.loads`.  Here is
+an example::
+
+ >>> import pvl
+ >>> pvl_text = "length = 42 <m/s>"
+ >>> regular = pvl.loads(pvl_text)
+ >>> print(regular['length'])  #doctest: +ELLIPSIS
+ Units(value=42, units=Token('m/s', '<pvl.grammar.OmniGrammar object at ...
+ >>> print(type(regular['length']))
+ <class 'pvl._collections.Units'>
+
+ >>> from pvl.decoder import OmniDecoder
+ >>> from astropy import units as u
+ >>> w_astropy = pvl.loads(pvl_text, decoder=OmniDecoder(quantity_cls=u.Quantity))
+ >>> print(w_astropy)
+ PVLModule([
+   ('length', <Quantity 42. m / s>)
+ ])
+ >>> print(type(w_astropy['length']))
+ <class 'astropy.units.quantity.Quantity'>
+
+However, in our example file and in other files you may parse, the
+units may be in upper case (e.g. KM, M), and by default, astropy will
+not recognize the name of these units.  It will raise a handy
+exception, which, in turn, will be raised as a
+:class:`pvl.parser.QuantityError` that will look like this::
+
+    pvl.parser.QuantityError: 'KM' did not parse as unit: At col
+    0, KM is not a valid unit. Did you mean klm or km? If this is
+    meant to be a custom unit, define it with 'u.def_unit'. To have
+    it recognized inside a file reader or other code, enable it
+    with 'u.add_enabled_units'. For details, see
+    http://docs.astropy.org/en/latest/units/combining_and_defining.html
+
+So, in order to parse our file, do this::
+
+ >>> import pvl
+ >>> from pvl.decoder import OmniDecoder
+ >>> from astropy import units as u
+ >>> pvl_file = 'tests/data/pds3/units1.lbl'
+ >>> km_upper = u.def_unit('KM', u.km)
+ >>> m_upper = u.def_unit('M', u.m)
+ >>> u.add_enabled_units([km_upper, m_upper])  #doctest: +ELLIPSIS
+ <astropy.units.core._UnitContext object at ...
+ >>> label = pvl.load(pvl_file, decoder=OmniDecoder(quantity_cls=u.Quantity))
+ >>> print(label)
+ PVLModule([
+   ('PDS_VERSION_ID', 'PDS3')
+   ('MSL:COMMENT', 'THING TEST')
+   ('FLOAT_UNIT', <Quantity 0.414 KM>)
+   ('INT_UNIT', <Quantity 4. M>)
+ ])
+ >>> print(type(label['FLOAT_UNIT']))
+ <class 'astropy.units.quantity.Quantity'>
+
+
+Similarly, :class:`astropy.units.Quantity` objects can be encoded to PVL text
+by :func:`pvl.dump` or :func:`pvl.dumps` without any particular special handling.
+Here is an example::
+
+ >>> import pvl
+ >>> from astropy import units as u
+ >>> my_label = dict(length=u.Quantity(15, u.m), velocity=u.Quantity(0.5, u.m / u.s))
+ >>> print(pvl.dumps(my_label))
+ LENGTH   = 15.0 <m>
+ VELOCITY = 0.5 <m / s>
+ END
+ <BLANKLINE>
+
+
+-------------
+pint.Quantity
+-------------
+The `Pint library <http://pint.readthedocs.org>`_ also deals with quantities.
+
+The :class:`pint.Quantity` object can also be returned in the data
+structure returned from :func:`pvl.load` or :func:`pvl.loads` if you 
+would prefer to use those objects.  Here is an example::
+
+ >>> import pvl
+ >>> pvl_text = "length = 42 <m/s>"
+ >>> from pvl.decoder import OmniDecoder
+ >>> import pint
+ >>> w_pint = pvl.loads(pvl_text, decoder=OmniDecoder(quantity_cls=pint.Quantity))
+ >>> print(w_pint)
+ PVLModule([
+   ('length', <Quantity(42, 'meter / second')>)
+ ])
+ >>> print(type(w_pint['length']))
+ <class 'pint.quantity.Quantity'>
+
+Just as with :class:`astropy.units.Quantity`, :class:`pint.Quantity` doesn't recognize
+the upper case units, and will raise an error like this::
+
+    pint.errors.UndefinedUnitError: 'KM' is not defined in the unit registry
+
+So, in order to parse our file with uppercase units, you can create
+a units definition file to add aliases and units to the pint
+'registry'. When doing this programmatically note that if you define
+a registry on-the-fly, you must use the registry's Quantity to the
+``quantity_cls`` argument::
+
+ >>> import pvl
+ >>> from pvl.decoder import OmniDecoder
+ >>> import pint
+ >>> ureg = pint.UnitRegistry()
+ >>> ureg.define('kilo- = 1000 = K- = k-')
+ >>> ureg.define('@alias meter = M')
+ >>> pvl_file = 'tests/data/pds3/units1.lbl'
+ >>> label = pvl.load(pvl_file, decoder=OmniDecoder(quantity_cls=ureg.Quantity))
+ >>> print(label)
+ PVLModule([
+   ('PDS_VERSION_ID', 'PDS3')
+   ('MSL:COMMENT', 'THING TEST')
+   ('FLOAT_UNIT', <Quantity(0.414, 'kilometer')>)
+   ('INT_UNIT', <Quantity(4, 'meter')>)
+ ])
+ >>> print(type(label['FLOAT_UNIT']))
+ <class 'pint.quantity.build_quantity_class.<locals>.Quantity'>
+
+Similarly, :class:`pint.Quantity` objects can be encoded to PVL text
+by :func:`pvl.dump` or :func:`pvl.dumps`::
+
+ >>> import pvl
+ >>> import pint
+ >>> ureg = pint.UnitRegistry()
+ >>> dist = 15 * ureg.m
+ >>> vel = 0.5 * ureg.m / ureg.second
+ >>> my_label = dict(length=dist, velocity=vel)
+ >>> print(pvl.dumps(my_label))
+ LENGTH   = 15 <meter>
+ VELOCITY = 0.5 <meter / second>
+ END
+ <BLANKLINE>

--- a/docs/quantities.rst
+++ b/docs/quantities.rst
@@ -3,24 +3,32 @@ Quantities: Values and Units
 ============================
 
 The PVL specifications supports the notion that PVL Value Expressions
-can contain an optional PVL Units Expression that follows the PVL Value.
+can contain an optional PVL Units Expression that follows the PVL
+Value.  This combination of information: a value followed by a unit
+can be represented by a single object that we might call a quantity.
 
-By default, the ``pvl`` library includes the :class:`pvl._collections.Units`
-class which is implemented as a :class:`collections.namedtuple` with
-a ``value`` and a ``unit`` parameter.  This kind of Python object, although
-not supported by the standard library, is sometimes also referred to as a
-'quantity' object in other 3rd party libraries.
+There is no fundamental Python object type that represents a value
+and the units of that value. However, libraries like ``astropy``
+and ``pint`` have implemented "quantity" objects (and managed to
+name them both Quantity, but they have slightly different interfaces).
+In order to avoid optional dependencies, the ``pvl`` library provides
+the :class:`pvl._collections.Units` class, implemented as a
+:class:`collections.namedtuple` with a ``value`` and a ``unit``
+parameter.  However, the ``unit`` parameter is just a string and
+so the ``pvl`` quantity objects doesn't have the super-powers that
+the ``astropy`` and ``pint`` quntity objects do.
 
-This means that when PVL text is parsed by :func:`pvl.load` or
-:func:`pvl.loads` when a PVL Value followed by a PVL Units Expression
-is encountered, the returned Python object will be a
-:class:`pvl._collections.Units` object.
+By default, this means that when PVL text is parsed by :func:`pvl.load`
+or :func:`pvl.loads` and when a PVL Value followed by a PVL Units
+Expression is encountered, a :class:`pvl._collections.Units` object
+will be placed in the returned dict-like.
 
 Likewise when :func:`pvl.dump` or :func:`pvl.dumps` encounters a
 :class:`pvl._collections.Units` its value and units will be serialized
 with the right PVL syntax.
 
-However, the ``pvl`` library also supports the use of other quantity objects.
+However, the ``pvl`` library also supports the use of other quantity
+objects.
 
 --------------------------------------------
 Getting other quantity objects from PVL text

--- a/docs/quantities.rst
+++ b/docs/quantities.rst
@@ -26,21 +26,23 @@ However, the ``pvl`` library also supports the use of other quantity objects.
 Getting other quantity objects from PVL text
 --------------------------------------------
 
-In order to get the parsing side of the ``pvl`` library to return a particular
-kind of quantity object when a PVL Value followed by a PVL Units Expression
-is found, can be achieved by passing the name of that quantity class to the
-decoder's ``quantity_cls`` argument.  This quantity class's constructor must
-take two arguments, where the first will receive the PVL Value (as whatever
-Python type ``pvl`` determines it to be) and the second will receive the 
-PVL Units Expression (as a ``str``).
+In order to get the parsing side of the ``pvl`` library to return
+a particular kind of quantity object when a PVL Value followed by
+a PVL Units Expression is found, you must pass the name of that
+quantity class to the decoder's ``quantity_cls`` argument.  This
+quantity class's constructor must take two arguments, where the
+first will receive the PVL Value (as whatever Python type ``pvl``
+determines it to be) and the second will receive the PVL Units
+Expression (as a ``str``).
 
-Examples of how to do this with :func:`pvl.load` or :func:`pvl.loads` are below
-for ``astropy`` and ``pint``.
+Examples of how to do this with :func:`pvl.load` or :func:`pvl.loads`
+are below for ``astropy`` and ``pint``.
 
-Depending on the PVL text that you are parsing, and the quantity class that you
-are using, you may get errors if the quantity class can't accept the PVL Units
-Expression, or if the *value* part of the quantity class can't handle all of the
-possible types of PVL Values (which can be Simple Values, Sets, or Sequences).
+Depending on the PVL text that you are parsing, and the quantity
+class that you are using, you may get errors if the quantity class
+can't accept the PVL Units Expression, or if the *value* part of
+the quantity class can't handle all of the possible types of PVL
+Values (which can be Simple Values, Sets, or Sequences).
 
 
 ----------------------------------------------
@@ -57,8 +59,29 @@ test for those objects).  Any other kind of quantity object in the
 data structure passed to :func:`pvl.dump` or :func:`pvl.dumps` will
 just be encoded as a string.
 
-Other types are possible, but require subclassing the encoder classes, or
-submitting a PR to the repo to add them.
+Other types are possible, but require additions to the encoder in
+use.  The :class:`astropy.units.Quantity` object is already handled
+by the ``pvl`` library, but if it wasn't, this is how you would
+enable it.  You just need the class name, the name of the
+property on the class that yields the value or magnitude (for
+:class:`astropy.units.Quantity` that is ``value``), and the property
+that yields the units (for :class:`astropy.units.Quantity` that is
+``unit``).  With those pieces in hand, we just need to instantiate
+an encoder and add the new quantity class and the names of those
+properties to it, and then pass it to :func:`pvl.dump` or
+:func:`pvl.dumps` as follows::
+
+ >>> import pvl
+ >>> from astropy import units as u
+ >>> my_label = dict(length=u.Quantity(15, u.m), velocity=u.Quantity(0.5, u.m / u.s))
+ >>> my_encoder = pvl.PDSLabelEncoder()
+ >>> my_encoder.add_quantity_cls(u.Quantity, 'value', 'unit')
+ >>> print(pvl.dumps(my_label, encoder=my_encoder))
+ LENGTH   = 15.0 <m>
+ VELOCITY = 0.5 <m / s>
+ END
+ <BLANKLINE>
+
 
 
 ----------------------

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -34,11 +34,14 @@ __all__ = [
 ]
 
 
-def load(path, **kwargs):
+def load(path, parser=None, grammar=None, decoder=None, **kwargs):
     """Returns a Python object from parsing the file at *path*.
 
     :param path: an :class:`os.PathLike` which presumably has a
         PVL Module in it to parse.
+    :param parser: defaults to :class:`pvl.parser.OmniParser()`.
+    :param grammar: defaults to :class:`pvl.grammar.OmniGrammar()`.
+    :param decoder: defaults to :class:`pvl.decoder.OmniDecoder()`.
     :param ``**kwargs``: the keyword arguments that will be passed
         to :func:`loads()` and are described there.
 
@@ -51,7 +54,8 @@ def load(path, **kwargs):
     cube file), that's fine, this function will just extract the
     decodable text.
     """
-    return loads(get_text_from(path), **kwargs)
+    return loads(get_text_from(path), parser=parser, grammar=grammar,
+                 decoder=decoder, **kwargs)
 
 
 def get_text_from(path) -> str:

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -21,7 +21,7 @@ from ._collections import (
 
 __author__ = 'The pvl Developers'
 __email__ = 'trevor@heytrevor.com'
-__version__ = '1.0.0-alpha.1'
+__version__ = '1.0.0-alpha.2'
 __all__ = [
     'load',
     'loads',

--- a/pvl/decoder.py
+++ b/pvl/decoder.py
@@ -243,7 +243,7 @@ class PVLDecoder(object):
            based on the decoder's *quantity_cls*.
         """
         try:
-            return self.quantity_cls(value, unit)
+            return self.quantity_cls(value, str(unit))
         except ValueError as err:
             raise QuantityError(err)
 

--- a/pvl/decoder.py
+++ b/pvl/decoder.py
@@ -21,6 +21,7 @@ from itertools import repeat, chain
 from warnings import warn
 
 from .grammar import PVLGrammar, ODLGrammar
+from ._collections import Units
 
 
 def for_try_except(exception, function, *iterable):
@@ -44,15 +45,24 @@ def for_try_except(exception, function, *iterable):
     raise exception
 
 
+class QuantityError(Exception):
+    """A simple exception to distinguish errors from Quantity classes."""
+    pass
+
+
 class PVLDecoder(object):
     """A decoder based on the rules in the CCSDS-641.0-B-2 'Blue Book'
     which defines the PVL language.
 
-    *grammar* must be a pvl.grammar object, and defaults to
-    pvl.grammar.PVLGrammar()
+    :param grammar: defaults to a :class:`pvl.grammar.PVLGrammar`, but can
+        be any object that implements the :class:`pvl.grammar` interface.
+
+    :param quantity_cls: defaults to :class:`pvl._collections.Units`, but
+        could be any class object that takes two arguments, where the
+        first is the value, and the second is the units type.
     """
 
-    def __init__(self, grammar=None):
+    def __init__(self, grammar=None, quantity_cls=None):
         self.errors = []
 
         if grammar is None:
@@ -61,6 +71,11 @@ class PVLDecoder(object):
             self.grammar = grammar
         else:
             raise Exception
+
+        if quantity_cls is None:
+            self.quantity_cls = Units
+        else:
+            self.quantity_cls = quantity_cls
 
     def decode(self, value: str):
         """Returns a Python object based on *value*."""
@@ -221,6 +236,17 @@ class PVLDecoder(object):
 
         raise ValueError
 
+    def decode_quantity(self, value, unit):
+        """Returns a Python object that represents a value with
+           an associated unit, based on the values provided via
+           *value* and *unit*.  This function creates an object
+           based on the decoder's *quantity_cls*.
+        """
+        try:
+            return self.quantity_cls(value, unit)
+        except ValueError as err:
+            raise QuantityError(err)
+
 
 class ODLDecoder(PVLDecoder):
     """A decoder based on the rules in the PDS3 Standards Reference
@@ -231,13 +257,13 @@ class ODLDecoder(PVLDecoder):
     default to an ODLGrammar() object.
     """
 
-    def __init__(self, grammar=None):
+    def __init__(self, grammar=None, quantity_cls=None):
         self.errors = []
 
         if grammar is None:
-            super().__init__(grammar=ODLGrammar())
+            super().__init__(grammar=ODLGrammar(), quantity_cls=quantity_cls)
         else:
-            super().__init__(grammar=grammar)
+            super().__init__(grammar=grammar, quantity_cls=quantity_cls)
 
     def decode_datetime(self, value: str):
         """Extends parent function to also deal with datetimes

--- a/pvl/grammar.py
+++ b/pvl/grammar.py
@@ -242,4 +242,4 @@ class OmniGrammar(PVLGrammar):
     nondecimal_pre_re = re.compile(PVLGrammar._s +
                                    fr'(?P<radix>[2-9]|1[0-6])#{_ss}')
     nondecimal_re = re.compile(nondecimal_pre_re.pattern +
-                               fr'(?P<non_decimal>[0-9|A-F|a-f]+)#')
+                               r'(?P<non_decimal>[0-9|A-F|a-f]+)#')

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -56,7 +56,7 @@ will be thrown into the *tokens* generator iterator (via .throw()).
 import collections.abc as abc
 import re
 
-from ._collections import PVLModule, PVLGroup, PVLObject, Units
+from ._collections import PVLModule, PVLGroup, PVLObject
 from .token import Token
 from .grammar import PVLGrammar, OmniGrammar
 from .decoder import PVLDecoder, OmniDecoder
@@ -704,7 +704,7 @@ class PVLParser(object):
                              'Was expecting a units character, but found a '
                              f'unit delimiter, "{d}" instead.')
 
-        return Units(value, str(units_value))
+        return self.decoder.decode_quantity(value, units_value)
 
 
 class ODLParser(PVLParser):

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -337,7 +337,7 @@ class PVLParser(object):
                 tokens.send(t)
                 raise ValueError(f'Expecting "=", got: {t}')
             except StopIteration:
-                raise ParseError(f'Expecting "=", but ran out of tokens.')
+                raise ParseError('Expecting "=", but ran out of tokens.')
 
         self.parse_WSC_until(None, tokens)
         return

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -472,7 +472,7 @@ class PVLParser(object):
                 raise ValueError('Expecting a Parameter Name, but '
                                  f'found: "{t}"')
         except StopIteration:
-            raise ParseError('Ran out of tokens before starting to parse '
+            raise ValueError('Ran out of tokens before starting to parse '
                              'an Assignment-Statement.')
 
         Value = None

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.0.0-alpha.1',
+    version='1.0.0-alpha.2',
     description='Python implementation of PVL (Parameter Value Language)',
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',

--- a/tests/data/isis_output.txt
+++ b/tests/data/isis_output.txt
@@ -1,0 +1,13 @@
+Group = Results
+  From                    = test_Hidestripe-out.diff.cub
+  Band                    = 1
+  TotalPixels             = 2048000
+  ValidPixels             = 0
+  OverValidMaximumPixels  = 0
+  UnderValidMinimumPixels = 0
+  NullPixels              = 0
+  LisPixels               = 0
+  LrsPixels               = 0
+  HisPixels               = 0
+  HrsPixels               = 2048000
+End_Group

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -20,6 +20,7 @@ import itertools
 import unittest
 
 from pvl.decoder import PVLDecoder, ODLDecoder, for_try_except
+from pvl._collections import Units
 
 
 class TestForTryExcept(unittest.TestCase):
@@ -119,6 +120,26 @@ class TestDecoder(unittest.TestCase):
                  ('false', False)):
             with self.subTest(pair=p):
                 self.assertEqual(p[1], self.d.decode_simple_value(p[0]))
+
+    def test_decode_quantity(self):
+        q = self.d.decode_quantity('15', 'm/s')
+        self.assertEqual(q, Units('15', 'm/s'))
+
+        try:
+            from astropy import units as u
+            d = PVLDecoder(quantity_cls=u.Quantity)
+            q = d.decode_quantity('15', 'm/s')
+            self.assertEqual(q, u.Quantity('15', 'm/s'))
+        except ImportError:  # astropy isn't available.
+            pass
+
+        try:
+            from pint import Quantity as pintquant
+            d = PVLDecoder(quantity_cls=pintquant)
+            q = d.decode_quantity('15', 'm/s')
+            self.assertEqual(q, pintquant('15', 'm/s'))
+        except ImportError:  # pint isn't available.
+            pass
 
 
 class TestODLDecoder(unittest.TestCase):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -129,8 +129,8 @@ END;'''
         self.assertEqual(s, self.e.encode(m))
 
     def test_encode_quantity(self):
-        p = (Units(34, 'm/s'), '34 <m/s>')
-        self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+        q, s = Units(34, 'm/s'), '34 <m/s>'
+        self.assertEqual(s, self.e.encode_quantity(q))
 
         self.assertRaises(ValueError, self.e.encode_quantity, 'not a quant')
 
@@ -141,8 +141,8 @@ END;'''
             # It doesn't violate the PVL spec, but may cause users
             # a surprise.  However, if they are using Astropy
             # Quantities, they are theoretically aware of all that.
-            p = (u.Quantity(34, 'm/s'), '34.0 <m / s>')
-            self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+            q, s = u.Quantity(34, 'm/s'), '34.0 <m / s>'
+            self.assertEqual(s, self.e.encode_quantity(q))
         except ImportError:  # astropy isn't available.
             pass
 
@@ -151,8 +151,8 @@ END;'''
             # pint.Quantity also has its own peculiarities about
             # formating the output.  Again, doesn't break the spec,
             # but may cause surprises.
-            p = (pintquant(34, 'm/s'), '34 <meter / second>')
-            self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+            q, s = pintquant(34, 'm/s'), '34 <meter / second>'
+            self.assertEqual(s, self.e.encode_quantity(q))
         except ImportError:  # pint isn't available.
             pass
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -128,6 +128,34 @@ END_GROUP = foo;
 END;'''
         self.assertEqual(s, self.e.encode(m))
 
+    def test_encode_quantity(self):
+        p = (Units(34, 'm/s'), '34 <m/s>')
+        self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+
+        self.assertRaises(ValueError, self.e.encode_quantity, 'not a quant')
+
+        try:
+            from astropy import units as u
+            # astropy.units.Quantity makes values floating point
+            # and appears to print the units with spaces.
+            # It doesn't violate the PVL spec, but may cause users
+            # a surprise.  However, if they are using Astropy
+            # Quantities, they are theoretically aware of all that.
+            p = (u.Quantity(34, 'm/s'), '34.0 <m / s>')
+            self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+        except ImportError:  # astropy isn't available.
+            pass
+
+        try:
+            from pint import Quantity as pintquant
+            # pint.Quantity also has its own peculiarities about
+            # formating the output.  Again, doesn't break the spec,
+            # but may cause surprises.
+            p = (pintquant(34, 'm/s'), '34 <meter / second>')
+            self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+        except ImportError:  # pint isn't available.
+            pass
+
 
 class TestODLDecoder(unittest.TestCase):
 
@@ -139,6 +167,14 @@ class TestODLDecoder(unittest.TestCase):
         self.assertTrue(self.e.is_scalar('scalar'))
         self.assertTrue(self.e.is_scalar(Units(5, 'm')))
         self.assertFalse(self.e.is_scalar(Units('five', 'm')))
+
+    def test_encode_quantity(self):
+        try:
+            from astropy import units as u
+            p = (u.Quantity(34, 'm/s'), '34.0 <m / s>')
+            self.assertEqual(p[1], self.e.encode_quantity(p[0]))
+        except ImportError:  # astropy isn't available.
+            pass
 
 
 class TestPDSLabelEncoder(unittest.TestCase):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -74,6 +74,20 @@ class TestLoad(unittest.TestCase):
         string_path = str(self.simple)
         self.assertEqual(self.simplePVL, pvl.load(string_path))
 
+    def test_load_w_quantity(self):
+        try:
+            from astropy import units as u
+            from pvl.decoder import OmniDecoder
+            pvl_file = 'tests/data/pds3/units1.lbl'
+            km_upper = u.def_unit('KM', u.km)
+            m_upper = u.def_unit('M', u.m)
+            u.add_enabled_units([km_upper, m_upper])
+            label = pvl.load(pvl_file,
+                             decoder=OmniDecoder(quantity_cls=u.Quantity))
+            self.assertEqual(label['FLOAT_UNIT'], u.Quantity(0.414, 'KM'))
+        except ImportError:
+            pass
+
 
 class TestISIScub(unittest.TestCase):
 

--- a/tests/test_pvl.py
+++ b/tests/test_pvl.py
@@ -760,6 +760,11 @@ def test_delimiters():
     assert label['embedded_group']['foo'] == 'bar'
 
 
+def test_isis_output():
+    label = pvl.load(os.path.join(DATA_DIR, 'isis_output.txt'))
+    assert label['Results']['TotalPixels'] == 2048000
+
+
 def test_cube_label():
     with open(os.path.join(DATA_DIR, 'pattern.cub'), 'rb') as fp:
         label = pvl.load(fp)


### PR DESCRIPTION
This PR addresses #22 to adapt the new 1.0.0-alpha architecture to deal with quantity objects like astropy.units.Quantity and pint.Quantity objects.  Also provides generic ability for the user to add quantity objects without needing to subclass.  Review docs/quantities.rst for an overview.