### PR TITLE
Bugfix for scientific notation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,12 +3,18 @@
 History
 -------
 
+1.0.0-alpha.1 (2020-04-17)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a bugfix on 1.0.0-alpha to properly parse scientific notation
+and deal with properly catching an error.
+
+
 1.0.0-alpha (winter 2019-2020)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The above label will be changed and this paragraph will be removed
-when the decision is made to release 1.0.0.  This work is categorized
-as 1.0.0-alpha because backwards-incompatible changes are being
-introduced to the codebase.
+This is the alpha version of release 1.0.0 for pvl, and the items
+here and in other 'alpha' entries may be consolidated when 1.0.0
+is released.  This work is categorized as 1.0.0-alpha because
+backwards-incompatible changes are being introduced to the codebase.
 
 * Refactored code so that it will no longer support Python 2, 
   and is only guaranteed to work with Python 3.6 and above.

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -21,7 +21,7 @@ from ._collections import (
 
 __author__ = 'The pvl Developers'
 __email__ = 'trevor@heytrevor.com'
-__version__ = '1.0.0-alpha'
+__version__ = '1.0.0-alpha.1'
 __all__ = [
     'load',
     'loads',

--- a/pvl/lexer.py
+++ b/pvl/lexer.py
@@ -333,6 +333,13 @@ def lex_continue(char: str, next_char: str, lexeme: str,
     if g.nondecimal_pre_re.fullmatch(lexeme + next_char) is not None:
         return True
 
+    # Since the numeric signs could be in the reserved characters,
+    # make sure we can parse scientific notation correctly:
+    if(char.lower() == 'e'
+       and next_char in g.numeric_start_chars
+       and Token(lexeme + next_char + '2', grammar=g).is_numeric()):
+        return True
+
     # Some datetimes can have trailing numeric tz offsets,
     # if the decoder allows it, this means there could be
     # a '+' that splits the lexeme that we don't want.

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -628,8 +628,14 @@ class PVLParser(object):
                     value = p(tokens)
                     break
                 except LexerError:
+                    # A LexerError is a subclass of ValueError, but
+                    # if we get a LexerError, that's a problem and
+                    # we need to raise it, and not let it pass.
                     raise
                 except ValueError:
+                    # Getting a ValueError is a normal conseqence of
+                    # one of the parsing strategies not working,
+                    # this pass allows us to go to the next one.
                     pass
             else:
                 tokens.throw(ValueError,

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -520,7 +520,7 @@ class PVLParser(object):
         t = next(tokens)
         if t != delimiters[0]:
             tokens.send(t)
-            raise ValueError(f'Expecting a begin delimiter "{delimiters[0]} =" '
+            raise ValueError(f'Expecting a begin delimiter "{delimiters[0]}" '
                              f'but found: "{t}"')
         set_seq = list()
         # Initial WSC and/or empty
@@ -627,6 +627,8 @@ class PVLParser(object):
                 try:
                     value = p(tokens)
                     break
+                except LexerError:
+                    raise
                 except ValueError:
                     pass
             else:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.0.0-alpha',
+    version='1.0.0-alpha.1',
     description='Python implementation of PVL (Parameter Value Language)',
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -237,7 +237,8 @@ class TestLexer(unittest.TestCase):
 
     def test_numeric(self):
         pairs = (('Number: +79', ['Number:', '+79']),
-                 ('Binary: +2#0101#', ['Binary:', '+2#0101#']))
+                 ('Binary: +2#0101#', ['Binary:', '+2#0101#']),
+                 ('Scientific_notation: 2e+2', ['Scientific_notation:', '2e+2']))
         # ('Binary: +2#0101#', ['Binary:', '+2', '#', '0101', '#']))
         for p in pairs:
             with self.subTest(pairs=p):


### PR DESCRIPTION
@michaelaye noted that he had trouble with a particular label.  Turns out that we weren't parsing scientific notation completely correctly.  We did fine with '1e2' or '1e-2', but since '+' is a reserved character in PVL, '1e+2' got broken up on the plus.

This fixes that, and also catches an error properly that wasn't being caught.  The test label that @michaelaye shared now parses correctly with pvl.load() and also with pvl_validate.