### PR TITLE
[WIP] adding http/https support for pvl load

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,7 @@ END'''
 class TestLoad(unittest.TestCase):
 
     def setUp(self):
+        self.url = 'https://raw.githubusercontent.com/planetarypy/pvl/master/tests/data/pds3/simple_image_1.lbl'
         self.simple = data_dir / 'pds3' / 'simple_image_1.lbl'
         self.simplePVL = pvl.PVLModule(
             {'PDS_VERSION_ID': 'PDS3',
@@ -73,6 +74,9 @@ class TestLoad(unittest.TestCase):
     def test_load_w_string_path(self):
         string_path = str(self.simple)
         self.assertEqual(self.simplePVL, pvl.load(string_path))
+
+    def test_load_url(self):
+        self.assertEqual(self.simplePVL, pvl.load(self.url))
 
     def test_load_w_quantity(self):
         try:


### PR DESCRIPTION
adds url support to load using urllib to allow remote file support, currently very simple, but this should be expanded to work against comparable list of sources as the GDAL virtual file system drivers.  I think using a library (Apache Libcloud or other) as an optional dependency could help this work.

as a bonus I tried to make a unit test against https://pds-rings.seti.org/holdings/calibrated/COISS_2xxx_v1.0/COISS_2070/data/1695761485_1695858003/N1695761485_1_CALIB.LBL but ran into a parsing issue