### PR TITLE
URL support via pvl.loadu()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.0.0.-alpha.4 (2020-05-29)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Added the pvl.loadu() function as a convenience function to load PVL text from
+  URLs.
+
 1.0.0-alpha.3 (2020-05-28)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Implemented tests in tox and Travis for Python 3.8, and discovered a bug

--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -239,3 +239,21 @@ Stricter parsing can be accomplished by passing a different grammar object
   Traceback (most recent call last):
     ...
   pvl.lexer.LexerError: (LexerError(...), 'Expecting an Aggregation Block, an Assignment Statement, or an End Statement, but found "#" : line 3 column 1 (char 67)')
+
+----------
+From a URL
+----------
+
+The :func:`pvl.loadu()` function returns a Python object (typically a
+:class:`pvl.PVLModule` object which is :class:`dict`-like) based on
+parsing the PVL text in the data returned from a URL.
+
+This is very similar to parsing PVL text from a file, but you use
+:func:`pvl.loadu()` instead::
+
+ >>> import pvl
+ >>> url = 'https://raw.githubusercontent.com/planetarypy/pvl/master/tests/data/pds3/simple_image_1.lbl'
+ >>> pvl.loadu(url)['RECORD_TYPE']
+ 'FIXED_LENGTH'
+
+Of course, other kinds of URLs, like file, ftp, rsync, sftp and more can be used.

--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -252,8 +252,8 @@ This is very similar to parsing PVL text from a file, but you use
 :func:`pvl.loadu()` instead::
 
  >>> import pvl
- >>> url = 'https://raw.githubusercontent.com/planetarypy/pvl/master/tests/data/pds3/simple_image_1.lbl'
- >>> pvl.loadu(url)['RECORD_TYPE']
- 'FIXED_LENGTH'
+ >>> url = 'https://hirise-pds.lpl.arizona.edu/PDS/RDR/ESP/ORB_017100_017199/ESP_017173_1715/ESP_017173_1715_RED.LBL'
+ >>> pvl.loadu(url)['VIEWING_PARAMETERS']['PHASE_ANGLE']
+ Units(value=50.784875, units='DEG')
 
 Of course, other kinds of URLs, like file, ftp, rsync, sftp and more can be used.

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -23,7 +23,7 @@ from ._collections import (
 
 __author__ = 'The pvl Developers'
 __email__ = 'trevor@heytrevor.com'
-__version__ = '1.0.0-alpha.3'
+__version__ = '1.0.0-alpha.4'
 __all__ = [
     'load',
     'loads',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bumpversion]
+current_version = 0.3.0
+
 [wheel]
 universal = 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bumpversion]
-current_version = 0.3.0
-
 [wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.0.0-alpha.3',
+    version='1.0.0-alpha.4',
     description='Python implementation of PVL (Parameter Value Language)',
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -45,6 +45,8 @@ class TestLoad(unittest.TestCase):
 
     def setUp(self):
         self.simple = data_dir / 'pds3' / 'simple_image_1.lbl'
+        rawurl = 'https://raw.githubusercontent.com/planetarypy/pvl/master/'
+        self.url = rawurl + str(self.simple)
         self.simplePVL = pvl.PVLModule(
             {'PDS_VERSION_ID': 'PDS3',
              'RECORD_TYPE': 'FIXED_LENGTH',
@@ -73,6 +75,21 @@ class TestLoad(unittest.TestCase):
     def test_load_w_string_path(self):
         string_path = str(self.simple)
         self.assertEqual(self.simplePVL, pvl.load(string_path))
+
+    def test_loadu(self):
+        self.assertEqual(self.simplePVL, pvl.loadu(self.url))
+        self.assertEqual(
+            self.simplePVL, pvl.loadu(self.simple.resolve().as_uri())
+        )
+
+    @patch("pvl.loads")
+    @patch("pvl.decode_by_char")
+    def test_loadu_args(self, m_decode, m_loads):
+        pvl.loadu(self.url, data=None)
+        pvl.loadu(self.url, noturlopen="should be passed to loads")
+        m_decode.assert_called()
+        self.assertNotIn("data", m_loads.call_args_list[0][1])
+        self.assertIn("noturlopen", m_loads.call_args_list[1][1])
 
     def test_load_w_quantity(self):
         try:


### PR DESCRIPTION
I really should stop using my holidays to hack on pvl.

Anyway, I was so enamored of Andrew's proof of concept (#50), that I went ahead and worked on it some more. Turns out, I think that having a separate loadu() function is the way to go, rather than trying to mush that into pvl.load(). Sure, we could come up with some smart logic to recognize URLs separate from plain PVL text, but since there are already two "loaders" (and the previous developers didn't try and make pvl.load() smart enough to tell the difference between PVL text and file-type things--although you could, I suppose), I think we should carry that on. So we have: pvl.load() for file-type things, pvl.loads() for Python strings with PVL text in them, and now pvl.loadu() for URLs.

I based this heavily on Andrew's POC, even though this isn't based on his fork.

Bonus fun: using the urllib methods allow us to support not just http/https, but also ftp, sftp, rsync, file URLs, etc.