### PR TITLE
datetime aware refinement

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+1.0.0-alpha.6 (2020-07-27)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Enforced that all datetime.time and datetime.datetime objects
+  returned should be timezone "aware."  This breaks 0.x functionality
+  where some were and some weren't.  Addresses #57.
+
+
 1.0.0-alpha.5 (2020-05-30)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ISIS creates PVL text with unquoted plus signs ("+"), needed to adjust

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -23,7 +23,7 @@ from ._collections import (
 
 __author__ = 'The pvl Developers'
 __email__ = 'trevor@heytrevor.com'
-__version__ = '1.0.0-alpha.5'
+__version__ = '1.0.0-alpha.6'
 __all__ = [
     'load',
     'loads',

--- a/pvl/decoder.py
+++ b/pvl/decoder.py
@@ -305,7 +305,7 @@ class ODLDecoder(PVLDecoder):
             # Otherwise ...
             match = re.fullmatch(r'(?P<dt>.+?)'  # the part before the sign
                                  r'(?P<sign>[+-])'  # required sign
-                                 r'(?P<hour>0?[1-9]|1[0-2])'  # 1 to 12
+                                 r'(?P<hour>0?[0-9]|1[0-2])'  # 0 to 12
                                  fr'(?:{self.grammar._M_frag})?',  # Minutes
                                  value)
             if match is not None:

--- a/pvl/encoder.py
+++ b/pvl/encoder.py
@@ -669,7 +669,7 @@ class ODLEncoder(PVLEncoder):
 
         t = super().encode_time(value)
 
-        if value.tzinfo is None:
+        if value.tzinfo is None or value.tzinfo == 0:
             return t + 'Z'
         else:
             td_str = str(value.utcoffset())

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.0.0-alpha.5',
+    version='1.0.0-alpha.6',
     description='Python implementation of PVL (Parameter Value Language)',
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -90,15 +90,19 @@ class TestDecoder(unittest.TestCase):
                     self.assertEqual(p[1], self.d.decode_non_decimal(p[0]))
 
     def test_decode_datetime(self):
+        utc = datetime.timezone.utc
         for p in(('2001-01-01', datetime.date(2001, 1, 1)),
                  ('2001-027', datetime.date(2001, 1, 27)),
                  ('2001-027Z', datetime.date(2001, 1, 27)),
-                 ('23:45', datetime.time(23, 45)),
-                 ('01:42:57', datetime.time(1, 42, 57)),
-                 ('12:34:56.789', datetime.time(12, 34, 56, 789000)),
-                 ('2001-027T23:45', datetime.datetime(2001, 1, 27, 23, 45)),
-                 ('2001-01-01T01:34Z', datetime.datetime(2001, 1, 1, 1, 34)),
-                 ('01:42:57Z', datetime.time(1, 42, 57)),
+                 ('23:45', datetime.time(23, 45, tzinfo=utc)),
+                 ('01:42:57', datetime.time(1, 42, 57, tzinfo=utc)),
+                 ('12:34:56.789', datetime.time(12, 34, 56, 789000,
+                                                tzinfo=utc)),
+                 ('2001-027T23:45', datetime.datetime(2001, 1, 27, 23, 45,
+                                                      tzinfo=utc)),
+                 ('2001-01-01T01:34Z', datetime.datetime(2001, 1, 1, 1, 34,
+                                                         tzinfo=utc)),
+                 ('01:42:57Z', datetime.time(1, 42, 57, tzinfo=utc)),
                  ('2001-12-31T01:59:60.123Z', '2001-12-31T01:59:60.123Z'),
                  ('01:00:60', '01:00:60')):
             with self.subTest(pair=p):
@@ -149,6 +153,7 @@ class TestODLDecoder(unittest.TestCase):
 
     def test_decode_datetime(self):
         try:
+            utc = datetime.timezone.utc
             from dateutil import tz
             tz_plus_7 = tz.tzoffset('+7', datetime.timedelta(hours=7))
 
@@ -156,19 +161,21 @@ class TestODLDecoder(unittest.TestCase):
                       ('1990-158', datetime.date(1990, 6, 7)),
                       ('2001-001', datetime.date(2001, 1, 1)),
                       ('2001-01-01', datetime.date(2001, 1, 1)),
-                      ('12:00', datetime.time(12)),
-                      ('12:00:45', datetime.time(12, 0, 45)),
-                      ('12:00:45.4571', datetime.time(12, 0, 45, 457100)),
-                      ('15:24:12Z', datetime.time(15, 24, 12)),
+                      ('12:00', datetime.time(12, tzinfo=utc)),
+                      ('12:00:45', datetime.time(12, 0, 45, tzinfo=utc)),
+                      ('12:00:45.4571', datetime.time(12, 0, 45, 457100,
+                                                      tzinfo=utc)),
+                      ('15:24:12Z', datetime.time(15, 24, 12, tzinfo=utc)),
                       ('01:12:22+07',
                        datetime.time(1, 12, 22, tzinfo=tz_plus_7)),
                       ('01:12:22+7',
                        datetime.time(1, 12, 22, tzinfo=tz_plus_7)),
                       ('01:10:39.4575+07',
                        datetime.time(1, 10, 39, 457500, tzinfo=tz_plus_7)),
-                      ('1990-07-04T12:00', datetime.datetime(1990, 7, 4, 12)),
+                      ('1990-07-04T12:00', datetime.datetime(1990, 7, 4, 12,
+                                                             tzinfo=utc)),
                       ('1990-158T15:24:12Z',
-                       datetime.datetime(1990, 6, 7, 15, 24, 12)),
+                       datetime.datetime(1990, 6, 7, 15, 24, 12, tzinfo=utc)),
                       ('2001-001T01:10:39+7',
                        datetime.datetime(2001, 1, 1, 1, 10, 39,
                                          tzinfo=tz_plus_7)),

--- a/tests/test_pvl.py
+++ b/tests/test_pvl.py
@@ -526,6 +526,7 @@ def test_dates():
     label = pvl.loads(some_pvl)
 
     tz_plus_7 = datetime.timezone(datetime.timedelta(hours=7))
+    utc = datetime.timezone.utc
 
     assert isinstance(label['date1'], datetime.date)
     assert label['date1'] == datetime.date(1990, 7, 4)
@@ -540,25 +541,26 @@ def test_dates():
     assert label['date4'] == datetime.date(2001, 1, 1)
 
     assert isinstance(label['time1'], datetime.time)
-    assert label['time1'] == datetime.time(12)
+    assert label['time1'] == datetime.time(12, tzinfo=utc)
 
     assert isinstance(label['time_s'], datetime.time)
-    assert label['time_s'] == datetime.time(12, 0, 45)
+    assert label['time_s'] == datetime.time(12, 0, 45, tzinfo=utc)
 
     assert isinstance(label['time_s_float'], datetime.time)
-    assert label['time_s_float'] == datetime.time(12, 0, 45, 457100)
+    assert label['time_s_float'] == datetime.time(12, 0, 45, 457100, tzinfo=utc)
 
     assert isinstance(label['time_tz1'], datetime.time)
-    assert label['time_tz1'] == datetime.time(15, 24, 12)
+    assert label['time_tz1'] == datetime.time(15, 24, 12, tzinfo=utc)
 
     assert isinstance(label['time_tz2'], datetime.time)
     assert label['time_tz2'] == datetime.time(1, 12, 22, tzinfo=tz_plus_7)
 
     assert isinstance(label['datetime1'], datetime.datetime)
-    assert label['datetime1'] == datetime.datetime(1990, 7, 4, 12)
+    assert label['datetime1'] == datetime.datetime(1990, 7, 4, 12, tzinfo=utc)
 
     assert isinstance(label['datetime2'], datetime.datetime)
-    assert label['datetime2'] == datetime.datetime(1990, 6, 7, 15, 24, 12)
+    assert label['datetime2'] == datetime.datetime(1990, 6, 7, 15, 24, 12,
+                                                   tzinfo=utc)
 
     assert isinstance(label['time_tz3'], datetime.time)
     assert label['time_tz3'] == datetime.time(1, 12, 22, tzinfo=tz_plus_7)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36, py37, py38, flake8
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
-    py.test tests
+    pytest
 deps =
     -r{toxinidir}/requirements.txt
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enforced that all datetime.time and datetime.datetime objects returned should be timezone "aware."  This breaks 0.x functionality where some were and some weren't.

## Related Issue
Closes #57 

## Motivation and Context
See detailed discussion in #57 

## How Has This Been Tested?
- make lint
- make docs
- make test

## Types of changes
- Breaking change (previously, the datetime objects returned by the 0.x architecture were not uniform, sometimes they were aware sometimes they were not.)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
