### PR TITLE
PDSLabenEncoder encode_time bugfix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,14 @@ and the release date, in year-month-day format (see examples below).
 Unreleased
 ----------
 
+1.0.1 (2020-09-21)
+------------------
+
+Fixed
++++++
+* The PDSLabelEncoder was improperly raising an exception if the Python datetime
+  object to encode had a tzinfo component that had zero offset from UTC.
+
 
 1.0.0 (2020-08-23)
 ------------------

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -24,7 +24,7 @@ from .collections import (
 
 __author__ = "The pvl Developers"
 __email__ = "rbeyer@rossbeyer.net"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __all__ = [
     "load",
     "loads",

--- a/pvl/encoder.py
+++ b/pvl/encoder.py
@@ -1043,7 +1043,9 @@ class PDSLabelEncoder(ODLEncoder):
         """
         t = PVLEncoder.encode_time(value)
 
-        if value.tzinfo is None or value.tzinfo.utcoffset(None) == 0:
+        if value.tzinfo is None or value.tzinfo.utcoffset(
+            None
+        ) == datetime.timedelta(0):
             return t + "Z"
         else:
             raise ValueError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<prerelease>[a-z]+)\.((?P<serial>\d+)))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.0.0',
+    version='1.0.1',
     description='Python implementation of PVL (Parameter Value Language)',
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -250,6 +250,9 @@ END_OBJECT = key"""
         )
         self.assertRaises(ValueError, self.e.encode_time, t)
 
+        t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
+        self.assertEqual("15:15:59Z", self.e.encode_time(t))
+
     def test_encode(self):
         m = PVLModule(a=PVLGroup(g1=2, g2=3.4), b="c")
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -248,7 +248,7 @@ END_OBJECT = key"""
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=0))
         )
-        self.assertRaises(ValueError, self.e.encode_time, t)
+        self.assertEqual("13:14:15Z", self.e.encode_time(t))
 
         t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
         self.assertEqual("15:15:59Z", self.e.encode_time(t))


### PR DESCRIPTION
## Description
The PDSLabelEncoder was improperly raising an exception if the Python datetime object to encode had a tzinfo component that had zero offset from UTC.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->
- make lint
- make docs
- make test-all

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
