### PR TITLE
Improved local tox tests and changed "make release" to use twine.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,10 @@ and the release date, in year-month-day format (see examples below).
 Unreleased
 ----------
 
+Changed
++++++++
+* Improved some build and test functionality.
+
 1.1.0 (2020-12-04)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,8 @@ docs:
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-release: clean
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+release: dist
+	twine upload dist/*
 
 dist: clean
 	python setup.py sdist

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -24,7 +24,7 @@ from .collections import (
 
 __author__ = "The pvl Developers"
 __email__ = "rbeyer@rossbeyer.net"
-__version__ = "1.1.0"
+__version__ = "1.2.0-dev"
 __all__ = [
     "load",
     "loads",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,17 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0-dev
 commit = False
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<prerelease>[a-z]+)\.((?P<serial>\d+)))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
-	{major}.{minor}.{patch}-{prerelease}.{serial}
+	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
-[bumpversion:part:prerelease]
-optional_value = beta
-values =
-	alpha
-	beta
+[bumpversion:part:release]
+optional_value = production
+values = 
+	dev
+	production
 
 [bumpversion:file:setup.py]
 
@@ -22,4 +22,3 @@ universal = 1
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,19 +7,19 @@ serialize =
 	{major}.{minor}.{patch}-{prerelease}.{serial}
 	{major}.{minor}.{patch}
 
-[wheel]
-universal = 1
-
-[tool:pytest]
-doctest_optionflags = NORMALIZE_WHITESPACE
-
 [bumpversion:part:prerelease]
 optional_value = beta
-values = 
+values =
 	alpha
 	beta
 
 [bumpversion:file:setup.py]
 
 [bumpversion:file:pvl/__init__.py]
+
+[wheel]
+universal = 1
+
+[tool:pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.1.0',
+    version='1.2.0-dev',
     description=(
         'Python implementation for PVL (Parameter Value Language) '
         'parsing and encoding.'

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,14 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 setup(
     name='pvl',
     version='1.1.0',
-    description='Python implementation of PVL (Parameter Value Language)',
+    description=(
+        'Python implementation for PVL (Parameter Value Language) '
+        'parsing and encoding.'
+    ),
     long_description=readme + '\n\n' + history,
     author='The PlanetaryPy Developers',
-    author_email='rbeyer@rossbeyer.net',
+    maintainer="Ross Beyer",
+    maintainer_email="rbeyer@rossbeyer.net",
     url='https://github.com/planetarypy/pvl',
     packages=[
         'pvl',
@@ -38,6 +42,12 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Topic :: Text Processing'
     ],
+    extras_require={
+        "allopts": ["astropy", "multidict", "pint", "python-dateutil"],
+        "dateutil":  ["python-dateutil"],
+        "multidict": ["multidict"],
+        "quantities": ["astropy", "pint"],
+    },
     entry_points={"console_scripts": [
         "pvl_translate = pvl.pvl_translate:main",
         "pvl_validate= pvl.pvl_validate:main",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, flake8
+envlist = py{36, 37, 38}-{default, allopts}, flake8
 
 [testenv]
 setenv =
@@ -7,9 +7,19 @@ setenv =
 commands =
     pytest
 deps =
-    -r{toxinidir}/requirements.txt
+    pytest
+
+[testenv:py{36, 37, 38}-allopts]
+deps =
+    astropy
+    multidict
+    pint
+    python-dateutil
+    pytest
 
 [testenv:flake8]
+deps =
+    flake8
 commands =
     flake8 pvl tests
 


### PR DESCRIPTION
## Description
Set up the local tox tests (run via "make test-all") to test both the no-dependency version of pvl, and the version where all of the optional dependencies are present.

## Motivation and Context
I wanted to be able to easily test pvl lcoally with and without its optional dependencies.

## How Has This Been Tested?
- make lint
- make docs
- make test-all

## Types of changes
- New feature, in the build only (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
