### PR TITLE
Improved time encoding and decoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,26 +33,29 @@ Unreleased
 Added
 +++++
 * Added a default_timezone parameter to grammar objects so that they could
-  both communicate whether they allowed a default timezone (if not None),
+  both communicate whether they had a default timezone (if not None),
   and what it was.
-* Added a pvl.grammar.PDSGrammar class that properly restricts the allowed
-  timezone formats beyond that of the ODLGrammar.
+* Added a pvl.grammar.PDSGrammar class that specifies the default UTC
+  time offset.
 * Added a pvl.decoder.PDSLabelDecoder class that properly enforces only
-  milisecond time precision (not microsecond as ODL allows).
+  milisecond time precision (not microsecond as ODL allows), and does
+  not allow times with a +HH:MM timezone specifier.  It does assume
+  any time without a timezone specifier is a UTC time.
 
 Fixed
 +++++
-* The pvl.decoder.ODLDecoder now will return both "aware" and "naive"
+* pvl.decoder.ODLDecoder now will return both "aware" and "naive"
   datetime objects (as appropriate) since "local" times without a
   timezone are allowed under ODL.
-* The pvl.decoder.ODLDecoder will now properly reject any unquoted string
+* pvl.decoder.ODLDecoder will now properly reject any unquoted string
   that does not parse as an ODL Identifier.
-* The pvl.encoder.PDSLabelEncoder will now properly raise an exception if
+* pvl.decoder.ODLDecoder will raise an exception if there is a seconds value
+  of 60 (which the PVLDecoder allows)
+* pvl.encoder.ODLEncoder will raise an exception if given a "naive" time
+  object.
+* pvl.encoder.PDSLabelEncoder will now properly raise an exception if
   a time or datetime object cannot be represented with only milisecond
   precision.
-* The pvl.encoder.ODLEncoder will now properly write out "naive" times and
-  datetimes as PVL-text without assuming they are UTC times and enforcing
-  a timezone offset specifier.
 
 
 Changed

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,16 +35,32 @@ Added
 * Added a default_timezone parameter to grammar objects so that they could
   both communicate whether they allowed a default timezone (if not None),
   and what it was.
+* Added a pvl.grammar.PDSGrammar class that properly restricts the allowed
+  timezone formats beyond that of the ODLGrammar.
+* Added a pvl.decoder.PDSLabelDecoder class that properly enforces only
+  milisecond time precision (not microsecond as ODL allows).
 
 Fixed
 +++++
-* The pvl.decoder.ODLdecoder now will return both "aware" and "naive"
+* The pvl.decoder.ODLDecoder now will return both "aware" and "naive"
   datetime objects (as appropriate) since "local" times without a
   timezone are allowed under ODL.
+* The pvl.decoder.ODLDecoder will now properly reject any unquoted string
+  that does not parse as an ODL Identifier.
+* The pvl.encoder.PDSLabelEncoder will now properly raise an exception if
+  a time or datetime object cannot be represented with only milisecond
+  precision.
+* The pvl.encoder.ODLEncoder will now properly write out "naive" times and
+  datetimes as PVL-text without assuming they are UTC times and enforcing
+  a timezone offset specifier.
+
 
 Changed
 +++++++
 * Improved some build and test functionality.
+* Moved the is_identifier() static function from the ODLEncoder to the ODLDecoder
+  where it probably should have always been.
+
 
 1.1.0 (2020-12-04)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,18 @@ and the release date, in year-month-day format (see examples below).
 Unreleased
 ----------
 
+Added
++++++
+* Added a default_timezone parameter to grammar objects so that they could
+  both communicate whether they allowed a default timezone (if not None),
+  and what it was.
+
+Fixed
++++++
+* The pvl.decoder.ODLdecoder now will return both "aware" and "naive"
+  datetime objects (as appropriate) since "local" times without a
+  timezone are allowed under ODL.
+
 Changed
 +++++++
 * Improved some build and test functionality.

--- a/pvl/decoder.py
+++ b/pvl/decoder.py
@@ -199,13 +199,6 @@ class PVLDecoder(object):
         seconds.  However, the Python ``datetime`` classes don't
         support second values for more than 59 seconds.
 
-        Since the PVL Blue Book says that all PVl Date/Time Values
-        are represented in Universal Coordinated Time, then all
-        datetime objects that are returned datetime Python objects
-        should be timezone "aware."  A datetime.date object is always
-        "naive" but any datetime.time or datetime.datetime objects
-        returned from this function will be "aware."
-
         If a time with 60 seconds is encountered, it will not be
         returned as a datetime object (since that is not representable
         via Python datetime objects), but simply as a string.
@@ -255,9 +248,11 @@ class PVLDecoder(object):
                     pass
             if d is not None:
                 if d.utcoffset() is None:
-                    return d.replace(tzinfo=timezone.utc)
-                else:
-                    return d
+                    if value.endswith("Z"):
+                        return d.replace(tzinfo=timezone.utc)
+                    elif self.grammar.default_timezone is not None:
+                        return d.replace(tzinfo=self.grammar.default_timezone)
+                return d
 
         # if we can regex a 60-second time, return str
         if self.is_leap_seconds(value):

--- a/pvl/grammar.py
+++ b/pvl/grammar.py
@@ -25,6 +25,7 @@ but in the meantime, just leave an Issue on the GitHub repo.
 
 import re
 from collections import abc
+from datetime import timezone
 
 
 class PVLGrammar:
@@ -114,6 +115,9 @@ class PVLGrammar:
         fr"{nondecimal_pre_re.pattern}(?P<non_decimal>[0-9|A-Fa-f]+)#"
     )
 
+    # The PVL Blue Book says that all PVl Date/Time Values are represented
+    # in Universal Coordinated Time
+    default_timezone = timezone.utc
     _d_formats = ("%Y-%m-%d", "%Y-%j")
     _t_formats = ("%H:%M", "%H:%M:%S", "%H:%M:%S.%f")
     date_formats = _d_formats + tuple(x + "Z" for x in _d_formats)
@@ -183,6 +187,9 @@ class ODLGrammar(PVLGrammar):
     # ODL does not allow times with a seconds value of 60.
     leap_second_Ymd_re = None
     leap_second_Yj_re = None
+
+    # ODL allows "local" times without a timezone specifier.
+    default_timezone = None
 
     # ODL allows the radix to be from 2 to 16, but the optional sign
     # must be after the first octothorpe (#).  Why ODL thought this was

--- a/pvl/grammar.py
+++ b/pvl/grammar.py
@@ -174,7 +174,7 @@ class PVLGrammar:
 
 
 class ODLGrammar(PVLGrammar):
-    """This defines a PDS3 ODL grammar.
+    """This defines an ODL grammar.
 
     The reference for this grammar is the PDS3 Standards Reference
     (version 3.8, 27 Feb 2009) Chapter 12: Object Description
@@ -215,6 +215,27 @@ class ODLGrammar(PVLGrammar):
             return True
         except UnicodeError:
             return False
+
+
+class PDSGrammar(ODLGrammar):
+    """This defines a PDS3 ODL grammar.
+
+    The reference for this grammar is the PDS3 Standards Reference
+    (version 3.8, 27 Feb 2009) Chapter 12: Object Description
+    Language Specification and Usage.
+    """
+
+    # The PDS spec only allows allows miliseconds, not microseconds,
+    # but there is only a %f microseconds time format specifier in
+    # Python, and no miliseconds format specifier, so dealing with
+    # only the miliseconds will have to be enforced at the encoder and
+    # decoder stages.
+    date_formats = PVLGrammar._d_formats
+    time_formats = PVLGrammar._t_formats
+    datetime_formats = list()
+    for d in date_formats:
+        for t in time_formats:
+            datetime_formats.append(f"{d}T{t}")
 
 
 class ISISGrammar(PVLGrammar):

--- a/pvl/grammar.py
+++ b/pvl/grammar.py
@@ -230,12 +230,9 @@ class PDSGrammar(ODLGrammar):
     # Python, and no miliseconds format specifier, so dealing with
     # only the miliseconds will have to be enforced at the encoder and
     # decoder stages.
-    date_formats = PVLGrammar._d_formats
-    time_formats = PVLGrammar._t_formats
-    datetime_formats = list()
-    for d in date_formats:
-        for t in time_formats:
-            datetime_formats.append(f"{d}T{t}")
+
+    # PDSLabels default to UTC:
+    default_timezone = timezone.utc
 
 
 class ISISGrammar(PVLGrammar):

--- a/pvl/pvl_validate.py
+++ b/pvl/pvl_validate.py
@@ -25,9 +25,15 @@ from collections import OrderedDict
 
 import pvl
 from .lexer import LexerError
-from .grammar import PVLGrammar, ODLGrammar, ISISGrammar, OmniGrammar
+from .grammar import (
+    PVLGrammar,
+    ODLGrammar,
+    PDSGrammar,
+    ISISGrammar,
+    OmniGrammar,
+)
 from .parser import ParseError, PVLParser, ODLParser, OmniParser
-from .decoder import PVLDecoder, ODLDecoder, OmniDecoder
+from .decoder import PVLDecoder, ODLDecoder, PDSLabelDecoder, OmniDecoder
 from .encoder import PVLEncoder, ODLEncoder, ISISEncoder, PDSLabelEncoder
 
 # Some assembly required for the dialects.
@@ -38,7 +44,8 @@ _pvl_g = PVLGrammar()
 _pvl_d = PVLDecoder(grammar=_pvl_g)
 _odl_g = ODLGrammar()
 _odl_d = ODLDecoder(grammar=_odl_g)
-_odl_p = ODLParser(grammar=_odl_g, decoder=_odl_d)
+_pds_g = PDSGrammar()
+_pds_d = PDSLabelDecoder(grammar=_pds_g)
 _isis_g = ISISGrammar()
 _isis_d = OmniDecoder(grammar=_isis_g)
 _omni_g = OmniGrammar()
@@ -46,13 +53,13 @@ _omni_d = OmniDecoder(grammar=_omni_g)
 
 dialects = OrderedDict(
     PDS3=dict(
-        parser=_odl_p,
-        grammar=_odl_g,
-        decoder=_odl_d,
-        encoder=PDSLabelEncoder(grammar=_odl_g, decoder=_odl_d),
+        parser=ODLParser(grammar=_pds_g, decoder=_pds_d),
+        grammar=_pds_g,
+        decoder=_pds_d,
+        encoder=PDSLabelEncoder(grammar=_pds_g, decoder=_pds_d),
     ),
     ODL=dict(
-        parser=_odl_p,
+        parser=ODLParser(grammar=_odl_g, decoder=_odl_d),
         grammar=_odl_g,
         decoder=_odl_d,
         encoder=ODLEncoder(grammar=_odl_g, decoder=_odl_d),
@@ -86,7 +93,7 @@ def arg_parser():
         action="count",
         default=0,
         help="Will report the errors that are encountered.  A second v will "
-             "include tracebacks for non-pvl exceptions. ",
+        "include tracebacks for non-pvl exceptions. ",
     )
     p.add_argument("--version", action="version", version=pvl.__version__)
     p.add_argument(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -253,28 +253,31 @@ class TestPDS3Decoder(unittest.TestCase):
             ("1990-158", datetime.date(1990, 6, 7)),
             ("2001-001", datetime.date(2001, 1, 1)),
             ("2001-01-01", datetime.date(2001, 1, 1)),
-            ("12:00", datetime.time(12)),
-            ("12:00:45", datetime.time(12, 0, 45)),
+            ("12:00", datetime.time(12, tzinfo=utc)),
+            ("12:00:45", datetime.time(12, 0, 45, tzinfo=utc)),
+            ("15:24:12Z", datetime.time(15, 24, 12, tzinfo=utc)),
+            (
+                "1990-158T15:24:12Z",
+                datetime.datetime(1990, 6, 7, 15, 24, 12, tzinfo=utc)),
             (
                 "12:00:45.457",
-                datetime.time(12, 0, 45, 457000),
+                datetime.time(12, 0, 45, 457000, tzinfo=utc),
             ),
             (
                 "1990-07-04T12:00",
-                datetime.datetime(1990, 7, 4, 12),
+                datetime.datetime(1990, 7, 4, 12, tzinfo=utc),
             ),
         ):
             with self.subTest(pair=p):
                 self.assertEqual(p[1], self.d.decode_datetime(p[0]))
 
         for t in (
-                "15:24:12Z",
                 "01:12:22+07",
                 "01:12:22+7",
                 "01:10:39.4575+07",
-                "1990-158T15:24:12Z",
                 "2001-001T01:10:39+7",
                 "2001-001T01:10:39.457591+7",
+                "2001-001T01:10:39.457591",
         ):
             with self.subTest(time=t):
                 self.assertRaises(ValueError, self.d.decode_datetime, t)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -197,11 +197,11 @@ class TestODLDecoder(unittest.TestCase):
                 ("1990-158", datetime.date(1990, 6, 7)),
                 ("2001-001", datetime.date(2001, 1, 1)),
                 ("2001-01-01", datetime.date(2001, 1, 1)),
-                ("12:00", datetime.time(12, tzinfo=utc)),
-                ("12:00:45", datetime.time(12, 0, 45, tzinfo=utc)),
+                ("12:00", datetime.time(12)),
+                ("12:00:45", datetime.time(12, 0, 45)),
                 (
                     "12:00:45.4571",
-                    datetime.time(12, 0, 45, 457100, tzinfo=utc),
+                    datetime.time(12, 0, 45, 457100),
                 ),
                 ("15:24:12Z", datetime.time(15, 24, 12, tzinfo=utc)),
                 ("01:12:22+07", datetime.time(1, 12, 22, tzinfo=tz_plus_7)),
@@ -212,7 +212,7 @@ class TestODLDecoder(unittest.TestCase):
                 ),
                 (
                     "1990-07-04T12:00",
-                    datetime.datetime(1990, 7, 4, 12, tzinfo=utc),
+                    datetime.datetime(1990, 7, 4, 12),
                 ),
                 (
                     "1990-158T15:24:12Z",

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -234,3 +234,42 @@ class TestODLDecoder(unittest.TestCase):
 
         except ImportError:  # dateutil isn't available.
             pass
+
+class TestPDS3Decoder(unittest.TestCase):
+    def setUp(self):
+        self.d = PDS3Decoder()
+
+    def test_decode_datetime(self):
+        utc = datetime.timezone.utc
+
+        for p in (
+            ("1990-07-04", datetime.date(1990, 7, 4)),
+            ("1990-158", datetime.date(1990, 6, 7)),
+            ("2001-001", datetime.date(2001, 1, 1)),
+            ("2001-01-01", datetime.date(2001, 1, 1)),
+            ("12:00", datetime.time(12)),
+            ("12:00:45", datetime.time(12, 0, 45)),
+            (
+                "12:00:45.4571",
+                datetime.time(12, 0, 45, 457100),
+            ),
+            (
+                "1990-07-04T12:00",
+                datetime.datetime(1990, 7, 4, 12),
+            ),
+        ):
+            with self.subTest(pair=p):
+                self.assertEqual(p[1], self.d.decode_datetime(p[0]))
+
+
+        for t in (
+                "15:24:12Z",
+                "01:12:22+07",
+                "01:12:22+7",
+                "01:10:39.4575+07",
+                "1990-158T15:24:12Z",
+                "2001-001T01:10:39+7",
+                "2001-001T01:10:39.457591+7",
+        ):
+            with self.subTest(pair=p):
+                self.assertRaises(ValueError, self.d.decode_datetime, t)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -19,7 +19,7 @@ import datetime
 import itertools
 import unittest
 
-from pvl.decoder import PVLDecoder, ODLDecoder, for_try_except
+from pvl.decoder import PVLDecoder, ODLDecoder, PDSLabelDecoder, for_try_except
 from pvl.collections import Quantity
 
 
@@ -235,9 +235,10 @@ class TestODLDecoder(unittest.TestCase):
         except ImportError:  # dateutil isn't available.
             pass
 
+
 class TestPDS3Decoder(unittest.TestCase):
     def setUp(self):
-        self.d = PDS3Decoder()
+        self.d = PDSLabelDecoder()
 
     def test_decode_datetime(self):
         utc = datetime.timezone.utc
@@ -250,8 +251,8 @@ class TestPDS3Decoder(unittest.TestCase):
             ("12:00", datetime.time(12)),
             ("12:00:45", datetime.time(12, 0, 45)),
             (
-                "12:00:45.4571",
-                datetime.time(12, 0, 45, 457100),
+                "12:00:45.457",
+                datetime.time(12, 0, 45, 457000),
             ),
             (
                 "1990-07-04T12:00",
@@ -260,7 +261,6 @@ class TestPDS3Decoder(unittest.TestCase):
         ):
             with self.subTest(pair=p):
                 self.assertEqual(p[1], self.d.decode_datetime(p[0]))
-
 
         for t in (
                 "15:24:12Z",
@@ -271,5 +271,5 @@ class TestPDS3Decoder(unittest.TestCase):
                 "2001-001T01:10:39+7",
                 "2001-001T01:10:39.457591+7",
         ):
-            with self.subTest(pair=p):
+            with self.subTest(time=t):
                 self.assertRaises(ValueError, self.d.decode_datetime, t)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -273,7 +273,7 @@ END_OBJECT = key"""
         t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
         self.assertEqual("15:15:59", self.e.encode_time(t))
 
-        t = datetime.time(10, 54, 12, 129, tzinfo=datetime.timezone.utc)
+        t = datetime.time(10, 54, 12, 129000, tzinfo=datetime.timezone.utc)
         self.assertEqual("10:54:12.129", self.e.encode_time(t))
 
     def test_encode(self):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -7,7 +7,7 @@ from pvl.encoder import PVLEncoder, ODLEncoder, PDSLabelEncoder
 from pvl.collections import Quantity, PVLModule, PVLGroup, PVLObject
 
 
-class TestDecoder(unittest.TestCase):
+class TestEncoder(unittest.TestCase):
     def setUp(self):
         self.e = PVLEncoder()
 
@@ -163,7 +163,7 @@ END;"""
             pass
 
 
-class TestODLDecoder(unittest.TestCase):
+class TestODLEncoder(unittest.TestCase):
     def setUp(self):
         self.e = ODLEncoder()
 
@@ -181,6 +181,26 @@ class TestODLDecoder(unittest.TestCase):
             self.assertEqual(p[1], self.e.encode_quantity(p[0]))
         except ImportError:  # astropy isn't available.
             pass
+
+    def test_encode_time(self):
+        t = datetime.time(1, 2)
+        self.assertEqual("01:02", self.e.encode_time(t))
+
+        t = datetime.time(13, 14, 15,)
+        self.assertEqual("13:14:15", self.e.encode_time(t))
+
+        t = datetime.time(
+            13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
+        )
+        self.assertEqual("13:14:15+02", self.e.encode_time(t))
+
+        t = datetime.time(
+            13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=0))
+        )
+        self.assertEqual("13:14:15Z", self.e.encode_time(t))
+
+        t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
+        self.assertEqual("15:15:59Z", self.e.encode_time(t))
 
 
 class TestPDSLabelEncoder(unittest.TestCase):
@@ -235,10 +255,10 @@ END_OBJECT = key"""
 
     def test_encode_time(self):
         t = datetime.time(1, 2)
-        self.assertEqual("01:02Z", self.e.encode_time(t))
+        self.assertEqual("01:02", self.e.encode_time(t))
 
         t = datetime.time(13, 14, 15,)
-        self.assertEqual("13:14:15Z", self.e.encode_time(t))
+        self.assertEqual("13:14:15", self.e.encode_time(t))
 
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
@@ -248,10 +268,13 @@ END_OBJECT = key"""
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=0))
         )
-        self.assertEqual("13:14:15Z", self.e.encode_time(t))
+        self.assertEqual("13:14:15", self.e.encode_time(t))
 
         t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
-        self.assertEqual("15:15:59Z", self.e.encode_time(t))
+        self.assertEqual("15:15:59", self.e.encode_time(t))
+
+        t = datetime.time(10, 54, 12, 129, tzinfo=datetime.timezone.utc)
+        self.assertEqual("10:54:12.129", self.e.encode_time(t))
 
     def test_encode(self):
         m = PVLModule(a=PVLGroup(g1=2, g2=3.4), b="c")

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -184,10 +184,10 @@ class TestODLEncoder(unittest.TestCase):
 
     def test_encode_time(self):
         t = datetime.time(1, 2)
-        self.assertEqual("01:02", self.e.encode_time(t))
+        self.assertRaises(ValueError, self.e.encode_time, t)
 
         t = datetime.time(13, 14, 15,)
-        self.assertEqual("13:14:15", self.e.encode_time(t))
+        self.assertRaises(ValueError, self.e.encode_time, t)
 
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
@@ -255,11 +255,12 @@ END_OBJECT = key"""
 
     def test_encode_time(self):
         t = datetime.time(1, 2)
-        self.assertEqual("01:02", self.e.encode_time(t))
+        self.assertEqual("01:02Z", self.e.encode_time(t))
 
         t = datetime.time(13, 14, 15,)
-        self.assertEqual("13:14:15", self.e.encode_time(t))
+        self.assertEqual("13:14:15Z", self.e.encode_time(t))
 
+        # time objects with offsets other than zero should raise an Exception.
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
         )
@@ -268,13 +269,17 @@ END_OBJECT = key"""
         t = datetime.time(
             13, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=0))
         )
-        self.assertEqual("13:14:15", self.e.encode_time(t))
+        self.assertEqual("13:14:15Z", self.e.encode_time(t))
 
         t = datetime.time(15, 15, 59, tzinfo=datetime.timezone.utc)
-        self.assertEqual("15:15:59", self.e.encode_time(t))
+        self.assertEqual("15:15:59Z", self.e.encode_time(t))
 
         t = datetime.time(10, 54, 12, 129000, tzinfo=datetime.timezone.utc)
-        self.assertEqual("10:54:12.129", self.e.encode_time(t))
+        self.assertEqual("10:54:12.129Z", self.e.encode_time(t))
+
+        # time objects with precision greater than milisecond should raise
+        t = datetime.time(10, 54, 12, 123456, tzinfo=datetime.timezone.utc)
+        self.assertRaises(ValueError, self.e.encode_time, t)
 
     def test_encode(self):
         m = PVLModule(a=PVLGroup(g1=2, g2=3.4), b="c")


### PR DESCRIPTION
* The ODLDecoder:
    * May return a "naive" `time` object if not timezone specifier is present in the PVL-text
    * Will raise an exception if there is a seconds value of 60
* The ODLEncoder will raise an exception if given a "naive" `time` object.

* The PDSLabel Decoder:
    * PVL-text Times with a timezone specifier like +HH:MM will raise an exception.
    * PVL-text Times with precision better than milisecond will raise an exception.
    * PVL-text Times with no timezone specifier are assumed to be UTC.
    * Returned `time` objects will always be "aware" and have a timezone of UTC.
* The PVLEncoder will raise an exception if given a `time` value with better than milisecond precision.

Fixed so that PDS3 handling will not allow a time string with a timezone offset, and will not deal with time precisions better than miliseconds.

## Description
The ODL decoder will now return either "naive" or "aware" time and datetime objects, as appropriate.

Fixed so that PDS3 handling will not allow a time string with a timezone offset, and will properly raise exceptions if asked to deal with time precisions better than miliseconds (although ODL handling still allows microsecond precision).

## Related Issue
This would close #80.

## How Has This Been Tested?
- make lint
- make docs
- make test-all

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
