### PR TITLE
Enable Publish to PyPI on GitHub Release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,14 +21,15 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: |
         python setup.py sdist bdist_wheel
-    - name: Publish distribution to Test PyPI
+    - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-    # - name: Publish distribution to PyPI
+        password: ${{ secrets.PYPI_API_TOKEN }}
+
+    # - name: Publish distribution to Test PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1
     #   with:
     #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Description
The "publish to Test PyPI" in the workflow seemed to work just fine, when we created a GitHub Release, so now changing this to publish to PyPI "for real" the next time we create a GitHub release.

## Related Issue
Would close #78 

## How Has This Been Tested?
https://github.com/planetarypy/pvl/actions/runs/693934967

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
GitHub workflows only.

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.


<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
