### PR TITLE
Empty parameters inside groups or objects now properly allowed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,8 +27,8 @@ underlined with dashes under Unreleased_ with the version number
 and the release date, in year-month-day format (see examples below).
 
 
-Unreleased
-----------
+Not Yet Released
+----------------
 
 Added
 +++++
@@ -50,6 +50,10 @@ Fixed
   those weird UTF characters in the returned dict-like.  When the
   stricter PVL, ODL, or PDS3 dialects are used to "load" PVL-text,
   they will properly fail to parse this text. (Issue 93).
+* Empty parameters inside groups or objects (but not at the end), would
+  cause the default "Omni" parsing strategy to go into an infinite
+  loop.  Empty parameters in PVL, ODL, and PDS3 are not allowed (as
+  always).  (Issue 95).
 
 
 1.2.1 (2021-05-31)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 When updating this file, please add an entry for your change under
-Unreleased_ and one of the following headings:
+`Not Yet Released`_ and one of the following headings:
 
 - Added - for new features.
 - Changed - for changes in existing functionality.
@@ -39,7 +39,7 @@ Added
 * pvl.load() now has an `encoding=` parameter that is identical in usage
   to the parameter passed to `open()`, and will attempt to decode the whole
   file as if it had been encoded thusly.  If it encounters a decoding error,
-  it will fall back to decoding the bytes one at a time as ASCII text. (Issue 93)
+  it will fall back to decoding the bytes one at a time as ASCII text (Issue 93).
 
 Fixed
 +++++
@@ -49,11 +49,11 @@ Fixed
   so that if there are weird UTF characters in the PVL-text, you'll get
   those weird UTF characters in the returned dict-like.  When the
   stricter PVL, ODL, or PDS3 dialects are used to "load" PVL-text,
-  they will properly fail to parse this text. (Issue 93).
+  they will properly fail to parse this text (Issue 93).
 * Empty parameters inside groups or objects (but not at the end), would
   cause the default "Omni" parsing strategy to go into an infinite
-  loop.  Empty parameters in PVL, ODL, and PDS3 are not allowed (as
-  always).  (Issue 95).
+  loop.  Empty parameters in PVL, ODL, and PDS3 continue to not be
+  allowed (Issue 95).
 
 
 1.2.1 (2021-05-31)

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ with ``dict``-style access::
     ... ])
     >>> print(module['foo'])
     bar
-    >>> print(module.getlist('foo'))
+    >>> print(module.getall('foo'))
     ['bar', 'remember me?']
     >>> print(module.items())
     ItemsView(PVLModule([

--- a/pvl/collections.py
+++ b/pvl/collections.py
@@ -305,6 +305,21 @@ class OrderedMultiDict(dict, MutableMappingSequence):
     def pop(self, *args, **kwargs):
         """Removes all items with the specified *key*."""
 
+        if len(args) == 0 and len(kwargs) == 0:
+            if not self:
+                raise KeyError(
+                    "pop(): {!s} ".format(type(self).__name__) + "is empty"
+                )
+
+            key, _ = item = self.__items.pop()
+            values = dict_getitem(self, key)
+            values.pop()
+
+            if not values:
+                dict_delitem(self, key)
+
+            return item
+
         warnings.warn(
             "The pop(k) function removes "
             "all keys with value k to remain backwards compatible with the "
@@ -313,9 +328,6 @@ class OrderedMultiDict(dict, MutableMappingSequence):
             "Consider using .popall(k) instead.",
             FutureWarning,
         )
-
-        if len(args) == 0 and len(kwargs) == 0:
-            return self.popitem()
 
         return self.popall(*args, *kwargs)
 
@@ -329,22 +341,7 @@ class OrderedMultiDict(dict, MutableMappingSequence):
             "Consider using the list-like .pop(), without an argument instead.",
             FutureWarning,
         )
-        # Yes, I know .pop() without an argument just redirects here, but it
-        # won't always.
-
-        if not self:
-            raise KeyError(
-                "popitem(): {!s} ".format(type(self).__name__) + "is empty"
-            )
-
-        key, _ = item = self.__items.pop()
-        values = dict_getitem(self, key)
-        values.pop()
-
-        if not values:
-            dict_delitem(self, key)
-
-        return item
+        return self.pop()
 
     def copy(self):
         return type(self)(self)

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -339,8 +339,18 @@ class PVLParser(object):
                     # t = next(tokens)
                     # print(f'parsing agg block, next token is: {t}')
                     # tokens.send(t)
-                    self.parse_end_aggregation(begin, block_name, tokens)
-                    break
+                    try:
+                        self.parse_end_aggregation(begin, block_name, tokens)
+                        break
+                    except ValueError as ve:
+                        try:
+                            (agg, keep_parsing) = self.parse_module_post_hook(
+                                agg, tokens
+                            )
+                            if not keep_parsing:
+                                raise ve
+                        except Exception:
+                            raise ve
 
         return block_name, agg
 

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -839,7 +839,7 @@ class OmniParser(PVLParser):
         EmptyValueAtLine object.
         """
         # It enables this by checking to see if the next thing is an
-        # '=' which means there was an empty assigment at the previous
+        # '=' which means there was an empty assignment at the previous
         # equals sign, and then unwinding the stack to give the
         # previous assignment the EmptyValueAtLine() object and trying
         # to continue parsing.

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -305,7 +305,7 @@ class PVLParser(object):
         """
         raise Exception
 
-    def parse_aggregation_block(self, tokens: abc.Generator):
+    def parse_aggregation_block(self, tokens: abc.Generator):  # noqa: C901
         """Parses the tokens for an Aggregation Block, and returns
         the modcls object that is the result of the parsing and
         decoding.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -394,3 +394,10 @@ class TestOmni(unittest.TestCase):
             PVLModule(foo="bar", weird="comments", baz="bang"),
             self.p.parse(some_pvl),
         )
+
+    def test_parse_aggregation_block(self):
+        tokens = Lexer("GROUP = name robert = bob = uncle END_GROUP")
+        self.assertEqual(
+            ("name", PVLGroup(robert="", bob="uncle")),
+            self.p.parse_aggregation_block(tokens)
+        )


### PR DESCRIPTION
## Description
The strict PVL, ODL, and PDS3 dialects of PVL-text do not allow empty parameters, like so:
```
param1 = value1
param2 =
param3 = value3
```

However, given the vast amount of broken PVL-text out there, the "Omni" strategy used by default in the loaders, should handle this.  In general, it does.  However, there was a bug where if the above pattern was present inside a PVL group or object in the middle (at least one regular parameter/value pair after the missing value, as as above) the parsers would go into an infinite loop.  If the missing value was for the last parameter in the object or group it did not have this failure mode.

We already have a `parse_module_post_hook()` function that handled this for the general case, and this function is now properly implemented for parameters and values within groups and objects.

Also, while I was noticing it, the FutureWarnings on use of `.popitem()` and `.pop(k)` were also bleeding through when one was using `.pop()` in the "good" way.  So some rearranging of this code was done so that the FutureWarning only gets emitted when you're using these functions in the way that might be deprecated in the future.

## Related Issue
This would close #95.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->
- make lint
- make docs
- make test-all

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
