### PR TITLE
Fixed StopIteration error with nested Aggregation Blocks with mis-matched Block Names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,12 @@ and the release date, in year-month-day format (see examples below).
 Not Yet Released
 ----------------
 
+Fixed
++++++
+* Deeply nested Aggregation Blocks (Object or Group) which had mis-matched Block Names
+  should now properly result in LexerErrors instead of resulting in StopIteration Exceptions (Issue 100).
+
+
 1.3.0 (2021-09-10)
 ------------------
 

--- a/pvl/__init__.py
+++ b/pvl/__init__.py
@@ -24,7 +24,7 @@ from .collections import (
 
 __author__ = "The pvl Developers"
 __email__ = "rbeyer@rossbeyer.net"
-__version__ = "1.3.0"
+__version__ = "1.3.1-dev"
 __all__ = [
     "load",
     "loads",

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -326,6 +326,8 @@ class PVLParser(object):
             self.parse_WSC_until(None, tokens)
             try:
                 agg.append(*self.parse_aggregation_block(tokens))
+            except LexerError:
+                raise
             except ValueError:
                 try:
                     agg.append(*self.parse_assignment_statement(tokens))
@@ -342,6 +344,8 @@ class PVLParser(object):
                     try:
                         self.parse_end_aggregation(begin, block_name, tokens)
                         break
+                    except LexerError:
+                        raise
                     except ValueError as ve:
                         try:
                             (agg, keep_parsing) = self.parse_module_post_hook(
@@ -700,7 +704,7 @@ class PVLParser(object):
                     # we need to raise it, and not let it pass.
                     raise
                 except ValueError:
-                    # Getting a ValueError is a normal conseqence of
+                    # Getting a ValueError is a normal consequence of
                     # one of the parsing strategies not working,
                     # this pass allows us to go to the next one.
                     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='pvl',
-    version='1.3.0',
+    version='1.3.1-dev',
     description=(
         'Python implementation for PVL (Parameter Value Language) '
         'parsing and encoding.'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -247,6 +247,8 @@ class TestParse(unittest.TestCase):
         bad_blocks = (
             "Group = name bob = uncle END_OBJECT",
             "GROUP= name = bob = uncle END_GROUP",
+            "OBJECT = L1 V = 123 END_OBJECT = bad",
+            "OBJECT = L1 OBJECT = L2 V = 123 END_OBJECT = bad END_OBJECT = L1"
             "",
         )
         for b in bad_blocks:


### PR DESCRIPTION
## Description
Deeply nested Aggregation Blocks (Object or Group) which had mis-matched Block Names should cleanly emit a LexerError, but instead after that, the parser kept trying to parse and eventually terminated with a StopIteration
Exception.

LexerErrors are derived from ValueErrors, but these two different exceptions can signal different behaviors in
the code, and there were some places where only ValueErrors were being caught (which also scooped up the 
LexerErrors).  Now properly also dealing with LexerErrors.

## Related Issue
#100 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->
- make lint
- make docs
- make test

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
