### PR TITLE
Set ASCII NULL characters as "reserved" for default parsing.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,10 @@ Fixed
 +++++
 * Deeply nested Aggregation Blocks (Object or Group) which had mis-matched Block Names
   should now properly result in LexerErrors instead of resulting in StopIteration Exceptions (Issue 100).
+* The default "Omni" parsing strategy, now considers the ASCII NULL character ("\0") a "reserved character."
+  The practical effect is that the ASCII NULL can not be in parameter names or unquoted strings (but would still
+  be successfully parsed in quoted strings). This means that PVL-text that might have incorrectly used ASCII NULLs
+  as delimiters will once again be consumed by our omnivorous parser (Issue 98).
 
 
 1.3.0 (2021-09-10)

--- a/pvl/grammar.py
+++ b/pvl/grammar.py
@@ -333,8 +333,10 @@ class OmniGrammar(PVLGrammar):
     def __init__(self):
         # Handle the fact that ISIS writes out unquoted plus signs.
         # See ISISGrammar for details.
+        # Also add the ASCII NULL ("\0") to the reserved_characters tuple.
         self.reserved_characters = tuple(
-            ISISGrammar.adjust_reserved_characters(self.reserved_characters)
+            ISISGrammar.adjust_reserved_characters(self.reserved_characters) +
+            ["\0", ]
         )
 
     def char_allowed(self, char):

--- a/tests/test_pvl.py
+++ b/tests/test_pvl.py
@@ -842,6 +842,10 @@ def test_utf():
     label = pvl.load(utf_file)
     assert label["LABEL_REVISION_NOTE"] == "V1.0"
 
+    nulllabel = pvl.loads("foo=bar END\0wont=parse")
+    assert nulllabel["foo"] == "bar"
+    assert len(nulllabel) == 1
+
 
 def test_latin1():
     latin_file = os.path.join(BROKEN_DIR, "latin-1-degreesymb.pvl")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The default "Omni" parsing strategy, now considers the ASCII NULL character ("\0") a "reserved character." The practical effect is that the ASCII NULL can not be in parameter names or unquoted strings (but would still be successfully parsed in quoted strings). This means that PVL-text that might have incorrectly used ASCII NULLs as delimiters will once again be consumed by our omnivorous parser.

## Related Issue
Would close #98 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->
- make lint
- make docs

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
