### PR TITLE
Remove request of next token after end-statement

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         # install-target: ['.', '.[allopts]']
 
     steps:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         # install-target: ['.', '.[allopts]']
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,18 @@ and the release date, in year-month-day format (see examples below).
 Not Yet Released
 ----------------
 
+Fixed
++++++
+* The parser was requesting the next token after an end-statement, even
+  though nothing was done with this token (in the future it could
+  be a comment that should be processed).  In the very rare case
+  where all of the "data" bytes in a file with an attached PVL label
+  (like a .IMG or .cub file) actually convert to UTF with no
+  whitespace characters, that next token will take an unacceptable
+  amount of time to return, if it does at all.  The parser now does
+  not request additional tokens once an end-statement is identified
+  (Issue 104).
+
 
 1.3.1 (2022-02-05)
 ------------------

--- a/pvl/parser.py
+++ b/pvl/parser.py
@@ -496,16 +496,29 @@ class PVLParser(object):
                     f'"{end}"'
                 )
 
-            try:
-                t = next(tokens)
-                if t.is_WSC():
-                    # maybe process comment
-                    return
-                else:
-                    tokens.send(t)
-                    return
-            except LexerError:
-                pass
+            # The following commented code was originally put in place to deal
+            # with the possible future situation of being able to process
+            # the possible comment after an end-statement.
+            # In practice, an edge case was discovered (Issue 104) where "data"
+            # after an END statement *all* properly converted to UTF with no
+            # whitespace characters. So this request for the next token
+            # resulted in lexing more than 100 million "valid characters"
+            # and did not return in a prompt manner.  If we ever enable
+            # processing of comments, we'll have to figure out how to handle
+            # this case.  An alternate to removing this code is to leave it
+            # but put in a limit on the size that a lexeme can grow to,
+            # but that implies an additional if-statement for each character.
+            # This is the better solution for now.
+            # try:
+            #     t = next(tokens)
+            #     if t.is_WSC():
+            #         # maybe process comment
+            #         return
+            #     else:
+            #         tokens.send(t)
+            #         return
+            # except LexerError:
+            #     pass
         except StopIteration:
             pass
 


### PR DESCRIPTION
This bugfix removes the behavior in which the parser successfully parses and end-statement, and then requests the next token.  The intended behavior was to leave a hook for future parsing of a comment that could come after the end-statement.  However, in some rare cases, this request of another token could hang the whole process, and since nothing was done with the returned token, removing the request has no impact at this time.

I also added Python 3.10 to our GitHub Python testing workflow matrix.

## Related Issue
Issue #104 

## How Has This Been Tested?
- make lint
- make test

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the documentation accordingly.
- I have read the [**CONTRIBUTING** document](https://github.com/planetarypy/pvl/blob/master/CONTRIBUTING.rst).
- All existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/planetarypy/pvl/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/planetarypy/pvl/blob/master/AUTHORS.rst) file,
if you haven't already. -->

<!-- Thanks for contributing to pvl! -->
